### PR TITLE
Fix qt application imports

### DIFF
--- a/anystruct/qt_application.py
+++ b/anystruct/qt_application.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from .calc_structure_classes import (
+from anystruct.calc_structure_classes import (
     BucklingInput,
     CalcScantlings,
     Material,


### PR DESCRIPTION
## Summary
- replace the qt application module's relative imports with an absolute package import so it can be executed as a top-level script

## Testing
- not run (PySide6 is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f0c3b178e8832c846d4321dd6f9b90