### PR TITLE
Add main entry point for Qt demo app

### DIFF
--- a/anystruct/qt_application.py
+++ b/anystruct/qt_application.py
@@ -10,11 +10,13 @@ calculation back-end can be driven from the Qt layer.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Dict
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
+    QApplication,
     QLabel,
     QMainWindow,
     QPushButton,
@@ -23,7 +25,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from .calc_structure_classes import (
+from anystruct.calc_structure_classes import (
     BucklingInput,
     CalcScantlings,
     Material,
@@ -214,3 +216,16 @@ class DemoWindow(QMainWindow):
             f"{report}\n"
         )
         self._results.setPlainText(output)
+
+
+def main() -> int:
+    """Launch the demo Qt application."""
+
+    app = QApplication(sys.argv)
+    window = DemoWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a QApplication entry point so the Qt demo window can be launched by running the module directly
- register the DemoWindow inside the entry point and exit with the Qt event loop result

## Testing
- python -m compileall anystruct/qt_application.py

------
https://chatgpt.com/codex/tasks/task_e_68f0c3b178e8832c846d4321dd6f9b90