### PR TITLE
PR1: Add developer baseline configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ For documnetation:
 
 https://anystructure.readthedocs.io/en/latest/
 
+## Development setup ##
+
+ANYstructure is currently maintained as a Python package named `anystruct`. The GUI can still be launched through the `ANYstructure` console command after an editable install.
+
+Recommended local setup:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements-dev.txt
+python -m pip install -e .
+python -m pytest
+```
+
+Launch the desktop app after installation:
+
+```powershell
+ANYstructure
+```
+
+Excel/PULS workflows require a local Excel installation and are not expected to run in basic automated tests.
+
 ## The following is calculated: ##
 * Minimum plate thickness (DNV-OS-C101)
 * Minimum section modulus of stiffener/plate (DNVGL-OS-C101)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = ["-ra"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+build
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 matplotlib
 numpy
+Pillow
 reportlab
+scikit-learn
 scipy
 xlwings
-sklearn

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Scientific/Engineering'],
     keywords='dnv-gl-os-c101 dnv-rp-c202 dnv-rp-c201 naval_architecture structural_engineering steel buckling fatigue local_scantlings optimization weight',
     include_package_data=True,
-    install_requires=['scipy', 'numpy', 'matplotlib', 'reportlab', 'xlwings', 'scikit-learn'],
+    install_requires=['matplotlib', 'numpy', 'Pillow', 'reportlab', 'scikit-learn', 'scipy', 'xlwings'],
     packages=['anystruct'],
     py_modules = [],
 )


### PR DESCRIPTION
## Summary
- Add a minimal `pyproject.toml` with the setuptools build backend and pytest defaults.
- Add `requirements-dev.txt` for local development and test setup.
- Document the editable-install and pytest workflow in `README.md`.
- Align runtime dependency names across `requirements.txt` and `setup.py`, including `scikit-learn` and `Pillow`.

## Notes
- This intentionally keeps the existing `setup.py` metadata path intact to avoid changing package behavior in the first modernization step.
- No calculation or GUI code was changed.

## Verification
- Reviewed the GitHub compare diff and refetched changed files from the branch.
- Not run locally: this environment does not have a checked-out repository or `git` on PATH.