### PR TITLE
PR2: Add Windows pytest smoke CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - modern_dev
+  pull_request:
+    branches:
+      - modern_dev
+
+jobs:
+  pytest:
+    name: Python tests on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+
+      - name: Import package
+        run: python -c "import anystruct; print('anystruct import OK')"
+
+      - name: Run pytest
+        run: python -m pytest


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for pull requests and pushes to `modern_dev`.
- Run on `windows-latest` with Python 3.13.
- Install development dependencies, install the package editable, smoke-import `anystruct`, and run `python -m pytest`.

## Notes
- This intentionally starts with a single Windows job because the current application and tests have Windows-specific assumptions.
- No production, GUI, or calculation code is changed.

## Verification
- Reviewed the branch compare diff.
- Not run locally in this Codex environment because the workspace here is not a checked-out repository and `git` is not available on PATH.
- CI should run on this draft PR and provide the real verification signal.