### PR TITLE
PR3: Clean up GUI entrypoints

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,23 +1,5 @@
-import sys, multiprocessing, ctypes
-import tkinter as tk
-from anystruct.main_application import Application
+from anystruct.__main__ import main
 
-def main(args=None):
-    """The main routine."""
-    if args is None:
-        args = sys.argv[1:]
-
-    multiprocessing.freeze_support()
-    errorCode = ctypes.windll.shcore.SetProcessDpiAwareness(2)
-    root = tk.Tk()
-    width = root.winfo_screenwidth()
-    height = root.winfo_screenheight()
-    root.geometry(f'{width}x{height}')
-    my_app = Application(root)
-    root.mainloop()
-
-    # Do argument parsing here (eg. with argparse) and anything else
-    # you want your project to do.
 
 if __name__ == "__main__":
     main()

--- a/anystruct/__main__.py
+++ b/anystruct/__main__.py
@@ -1,24 +1,36 @@
-import sys, multiprocessing, ctypes, os
+import ctypes
+import multiprocessing
+import sys
 import tkinter as tk
+
 from anystruct.main_application import Application
 
-def main(args=None):
-    """The main routine."""
 
+def _set_windows_dpi_awareness():
+    if sys.platform != 'win32':
+        return
+
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    except (AttributeError, OSError):
+        pass
+
+
+def main(args=None):
+    """Launch the ANYstructure Tkinter application."""
     if args is None:
         args = sys.argv[1:]
 
     multiprocessing.freeze_support()
-    errorCode = ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    _set_windows_dpi_awareness()
+
     root = tk.Tk()
     width = root.winfo_screenwidth()
     height = root.winfo_screenheight()
     root.geometry(f'{width}x{height}')
-    my_app = Application(root)
+    Application(root)
     root.mainloop()
 
-    # Do argument parsing here (eg. with argparse) and anything else
-    # you want your project to do.
 
 if __name__ == "__main__":
     main()

--- a/anystruct/gui.py
+++ b/anystruct/gui.py
@@ -1,24 +1,5 @@
-import sys, multiprocessing, ctypes, os
-import tkinter as tk
-from anystruct.main_application import Application
+from anystruct.__main__ import main
 
-def main(args=None):
-    """The main routine."""
-
-    if args is None:
-        args = sys.argv[1:]
-
-    multiprocessing.freeze_support()
-    errorCode = ctypes.windll.shcore.SetProcessDpiAwareness(2)
-    root = tk.Tk()
-    width = root.winfo_screenwidth()
-    height = root.winfo_screenheight()
-    root.geometry(f'{width}x{height}')
-    my_app = Application(root)
-    root.mainloop()
-
-    # Do argument parsing here (eg. with argparse) and anything else
-    # you want your project to do.
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Centralize GUI launch logic in `anystruct.__main__`.
- Make the Windows DPI-awareness call platform-safe and best-effort.
- Replace the root `__main__.py` and `anystruct/gui.py` duplicates with thin wrappers.

## Notes
- The `ANYstructure = anystruct.__main__:main` console script remains unchanged.
- GUI behavior is intended to stay the same on Windows.
- This should make package import and non-Windows smoke tests less fragile without changing calculation code.

## Verification
- Reviewed the branch compare diff.
- Not run locally in this Codex environment because the workspace here is not a checked-out repository and `git` is not available on PATH.
- CI should run on this draft PR; please also launch `ANYstructure` locally before merging.