### PR TITLE
PR4: Document dependency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Launch the desktop app after installation:
 ANYstructure
 ```
 
+Dependency groups are also available for focused installs:
+
+```powershell
+python -m pip install -r requirements-core.txt
+python -m pip install -r requirements-ml.txt
+python -m pip install -r requirements-excel.txt
+```
+
+Equivalent package extras are exposed as `core`, `ml`, `excel`, `dev`, and `all`. The default package install still includes Excel and ML dependencies for backwards compatibility.
+
 Excel/PULS workflows require a local Excel installation and are not expected to run in basic automated tests.
 
 ## The following is calculated: ##

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,5 @@
+matplotlib
+numpy
+Pillow
+reportlab
+scipy

--- a/requirements-excel.txt
+++ b/requirements-excel.txt
@@ -1,0 +1,1 @@
+xlwings

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,1 @@
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,11 @@ def readme():
     with open('README.rst') as file:
         return file.read()
 
+core_requires = ['matplotlib', 'numpy', 'Pillow', 'reportlab', 'scipy']
+excel_requires = ['xlwings']
+ml_requires = ['scikit-learn']
+dev_requires = ['build', 'pytest']
+
 setup(
     name='ANYstructure',  # Required
     url = 'https://github.com/audunarn/ANYstructure',
@@ -41,7 +46,14 @@ setup(
         'Topic :: Scientific/Engineering'],
     keywords='dnv-gl-os-c101 dnv-rp-c202 dnv-rp-c201 naval_architecture structural_engineering steel buckling fatigue local_scantlings optimization weight',
     include_package_data=True,
-    install_requires=['matplotlib', 'numpy', 'Pillow', 'reportlab', 'scikit-learn', 'scipy', 'xlwings'],
+    install_requires=core_requires + excel_requires + ml_requires,
+    extras_require={
+        'core': core_requires,
+        'excel': excel_requires,
+        'ml': ml_requires,
+        'dev': dev_requires,
+        'all': core_requires + excel_requires + ml_requires,
+    },
     packages=['anystruct'],
     py_modules = [],
 )


### PR DESCRIPTION
## Summary
- Define named dependency groups in `setup.py`: `core`, `excel`, `ml`, `dev`, and `all`.
- Add split requirements files for core, Excel, and ML dependencies.
- Document focused dependency installs in `README.md`.

## Notes
- The default package install remains backwards-compatible and still includes Excel and ML dependencies.
- `requirements.txt` and `requirements-dev.txt` are unchanged, so CI and existing developer setup should continue to behave the same.
- No production, GUI, or calculation code is changed.

## Verification
- Reviewed the branch compare diff.
- Not run locally in this Codex environment because the workspace here is not a checked-out repository and `git` is not available on PATH.
- CI should run on this draft PR.