### PR TITLE
PR5: Add API characterization tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,53 @@
+import pytest
+
+from anystruct.api import CylStru, FlatStru
+
+
+def test_flat_structure_api_returns_special_provisions():
+    flat = FlatStru("Flat plate, stiffened")
+    flat.set_material(mat_yield=355, emodule=210000, material_factor=1.15, poisson=0.3)
+    flat.set_plate_geometry(spacing=700, thickness=18, span=4000)
+    flat.set_stresses(pressure=0.2, sigma_x1=50, sigma_x2=50, sigma_y1=100, sigma_y2=100, tau_xy=5)
+    flat.set_stiffener(hw=360, tw=12, bf=150, tf=20, stf_type="T", spacing=700)
+    flat.set_fixation_parameters(kpp=1, kps=1, km1=12, km2=24, km3=12)
+    flat.set_buckling_parameters(
+        calculation_method="DNV-RP-C201 - prescriptive",
+        buckling_acceptance="ultimate",
+        stiffened_plate_effective_aginst_sigy=True,
+    )
+
+    results = flat.get_special_provisions_results()
+
+    assert set(results) == {"Plate thickness", "Stiffener section modulus", "Stiffener shear area"}
+    for check in results.values():
+        assert check["minimum"] > 0
+        assert check["actual"] > 0
+
+
+def test_flat_structure_api_rejects_unknown_domain():
+    with pytest.raises(AssertionError):
+        FlatStru("not a domain")
+
+
+def test_cylinder_api_sets_basic_unstiffened_shell_properties():
+    cyl = CylStru(calculation_domain="Unstiffened shell")
+    cyl.set_material(mat_yield=355, emodule=210000, material_factor=1.15, poisson=0.3)
+    cyl.set_imperfection(delta_0=0.005)
+    cyl.set_fabrication_method(stiffener="Fabricated", girder="Fabricated")
+    cyl.set_end_cap_pressure_included_in_stress(is_included=True)
+    cyl.set_uls_or_als(kind="ULS")
+    cyl.set_shell_geometry(radius=6500, thickness=20, distance_between_rings=3000, tot_length_of_shell=12000)
+    cyl.set_shell_buckling_parmeters(eff_buckling_length_factor=1.0)
+    cyl.set_stresses(sasd=-50, smsd=0, tTsd=0, tQsd=10, psd=0.1, shsd=0)
+
+    props = cyl._CylinderMain.get_main_properties()
+
+    assert props["geometry"] == [1, ""]
+    assert props["mat_yield"] == [355e6, "Pa"]
+    assert props["ULS or ALS"] == ["ULS", ""]
+    assert props["psd"] == [100000.0, "Pa"]
+
+
+def test_cylinder_api_rejects_unknown_domain():
+    with pytest.raises(AssertionError):
+        CylStru(calculation_domain="not a domain")


### PR DESCRIPTION
## Summary
- Add characterization tests for the public `FlatStru` API setup flow and special-provisions output.
- Add constructor validation coverage for `FlatStru` and `CylStru` domains.
- Add a basic `CylStru` unstiffened-shell setup test that pins core converted properties.

## Notes
- No production, GUI, or calculation code is changed.
- These tests provide a small safety net before deeper refactors around API/core boundaries.

## Verification
- Reviewed the branch compare diff.
- Not run locally in this Codex environment because the workspace here is not a checked-out repository and `git` is not available on PATH.
- CI should run on this draft PR; please also run `python -m pytest` locally before merging.