### PR TITLE
PR6: Add import-boundary tests

### DIFF
--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+
+import pytest
+
+
+CORE_MODULES = [
+    "anystruct.calc_loads",
+    "anystruct.calc_structure",
+    "anystruct.helper",
+    "anystruct.make_grid_numpy",
+    "anystruct.optimize",
+]
+
+PUBLIC_MODULES = [
+    "anystruct.api",
+    "anystruct.report_generator",
+]
+
+
+@pytest.mark.parametrize("module_name", CORE_MODULES + PUBLIC_MODULES)
+def test_module_imports(module_name):
+    module = importlib.import_module(module_name)
+
+    assert module is not None
+
+
+@pytest.mark.parametrize("module_name", CORE_MODULES)
+def test_core_module_imports_without_tkinter_side_effect(module_name):
+    sys.modules.pop("tkinter", None)
+    sys.modules.pop("_tkinter", None)
+
+    importlib.import_module(module_name)
+
+    assert "tkinter" not in sys.modules
+    assert "_tkinter" not in sys.modules


### PR DESCRIPTION
## Summary
- Add smoke import coverage for core modules and public modules.
- Add a guard that core calculation modules should import without loading `tkinter` / `_tkinter` as a side effect.

## Notes
- No production, GUI, or calculation code is changed.
- This may expose an existing boundary issue, especially around `anystruct.optimize`, which currently imports `tkinter.filedialog` at module import time. If CI fails there, the failure is useful signal for the next cleanup patch.

## Verification
- Reviewed the branch compare diff.
- Not run locally in this Codex environment because the workspace here is not a checked-out repository and `git` is not available on PATH.
- CI should run on this draft PR; please also run `python -m pytest` locally before merging.