### PR TITLE
PR7: Add API helper module

### DIFF
--- a/anystruct/api_helpers.py
+++ b/anystruct/api_helpers.py
@@ -1,0 +1,57 @@
+FLAT_STRUCTURE_DOMAINS = (
+    "Flat plate, unstiffened",
+    "Flat plate, stiffened",
+    "Flat plate, stiffened with girder",
+)
+
+CYLINDER_STRUCTURE_DOMAINS = (
+    "Unstiffened shell",
+    "Unstiffened panel",
+    "Longitudinal Stiffened shell",
+    "Longitudinal Stiffened panel",
+    "Ring Stiffened shell",
+    "Ring Stiffened panel",
+    "Orthogonally Stiffened shell",
+    "Orthogonally Stiffened panel",
+)
+
+BUCKLING_CALCULATION_METHODS = (
+    "DNV-RP-C201 - prescriptive",
+    "ML-CL (PULS based)",
+)
+
+BUCKLING_ACCEPTANCE_TYPES = (
+    "buckling",
+    "ultimate",
+)
+
+SUPPORT_TYPES = (
+    "Continuous",
+    "Sniped",
+)
+
+FABRICATION_METHODS = (
+    "Fabricated",
+    "Cold formed",
+)
+
+LIMIT_STATE_TYPES = (
+    "ULS",
+    "ALS",
+)
+
+
+def assert_choice(value, choices, label):
+    assert value in choices, f"{label} must be one of: {list(choices)}"
+
+
+def mpa_to_pa(value):
+    return value * 1e6
+
+
+def mm_to_m(value):
+    return value / 1000
+
+
+def normalize_bulb_stiffener_type(stiffener_type):
+    return "L-bulb" if stiffener_type in ["hp", "HP", "HP-bulb", "bulb"] else stiffener_type

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1,0 +1,36 @@
+import pytest
+
+from anystruct import api_helpers
+
+
+def test_assert_choice_accepts_known_value():
+    api_helpers.assert_choice("ULS", api_helpers.LIMIT_STATE_TYPES, "limit state")
+
+
+def test_assert_choice_rejects_unknown_value():
+    with pytest.raises(AssertionError, match="limit state must be one of"):
+        api_helpers.assert_choice("SLS", api_helpers.LIMIT_STATE_TYPES, "limit state")
+
+
+def test_unit_conversions():
+    assert api_helpers.mpa_to_pa(355) == 355e6
+    assert api_helpers.mm_to_m(6500) == 6.5
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("hp", "L-bulb"),
+        ("HP", "L-bulb"),
+        ("HP-bulb", "L-bulb"),
+        ("bulb", "L-bulb"),
+        ("T", "T"),
+    ],
+)
+def test_normalize_bulb_stiffener_type(raw, expected):
+    assert api_helpers.normalize_bulb_stiffener_type(raw) == expected
+
+
+def test_domain_constants_include_public_api_values():
+    assert "Flat plate, stiffened" in api_helpers.FLAT_STRUCTURE_DOMAINS
+    assert "Orthogonally Stiffened shell" in api_helpers.CYLINDER_STRUCTURE_DOMAINS


### PR DESCRIPTION
## Summary
- Add a dependency-light `anystruct.api_helpers` module for API constants, validation, unit conversions, and bulb stiffener type normalization.
- Add focused tests for the new helper functions and public choice constants.

## Why
This creates a small, tested landing zone for future API cleanup before we start changing the large `anystruct/api.py` module. No existing API behavior is wired through these helpers yet, which keeps this PR low risk.

## Verification
- Reviewed the branch diff against `modern_dev`.
- Not run locally from this Codex environment; please run `python -m pytest` and let CI complete before merging.