### PR TITLE
PR9: Add API geometry mapping helpers

### DIFF
--- a/anystruct/api_helpers.py
+++ b/anystruct/api_helpers.py
@@ -40,9 +40,35 @@ LIMIT_STATE_TYPES = (
     "ALS",
 )
 
+FLAT_GEOMETRY_IDS = {
+    "Flat plate, unstiffened": 10,
+    "Flat plate, stiffened": 11,
+    "Flat plate, stiffened with girder": 12,
+}
+
+CYLINDER_GEOMETRY_IDS = {
+    "Unstiffened shell (Force input)": 1,
+    "Unstiffened panel (Stress input)": 2,
+    "Longitudinal Stiffened shell (Force input)": 3,
+    "Longitudinal Stiffened panel (Stress input)": 4,
+    "Ring Stiffened shell (Force input)": 5,
+    "Ring Stiffened panel (Stress input)": 6,
+    "Orthogonally Stiffened shell (Force input)": 7,
+    "Orthogonally Stiffened panel (Stress input)": 8,
+}
+
+GEOMETRY_IDS = {
+    **FLAT_GEOMETRY_IDS,
+    **CYLINDER_GEOMETRY_IDS,
+}
+
 
 def assert_choice(value, choices, label):
     assert value in choices, f"{label} must be one of: {list(choices)}"
+
+
+def geometry_id_for_domain(calculation_domain):
+    return GEOMETRY_IDS[calculation_domain]
 
 
 def mpa_to_pa(value):

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -12,6 +12,24 @@ def test_assert_choice_rejects_unknown_value():
         api_helpers.assert_choice("SLS", api_helpers.LIMIT_STATE_TYPES, "limit state")
 
 
+def test_geometry_id_for_flat_domain():
+    assert api_helpers.geometry_id_for_domain("Flat plate, unstiffened") == 10
+    assert api_helpers.geometry_id_for_domain("Flat plate, stiffened") == 11
+    assert api_helpers.geometry_id_for_domain("Flat plate, stiffened with girder") == 12
+
+
+def test_geometry_id_for_cylinder_domain_with_input_mode():
+    assert api_helpers.geometry_id_for_domain("Unstiffened shell (Force input)") == 1
+    assert api_helpers.geometry_id_for_domain("Unstiffened panel (Stress input)") == 2
+    assert api_helpers.geometry_id_for_domain("Orthogonally Stiffened shell (Force input)") == 7
+    assert api_helpers.geometry_id_for_domain("Orthogonally Stiffened panel (Stress input)") == 8
+
+
+def test_geometry_id_rejects_unknown_domain():
+    with pytest.raises(KeyError):
+        api_helpers.geometry_id_for_domain("Unknown geometry")
+
+
 def test_unit_conversions():
     assert api_helpers.mpa_to_pa(355) == 355e6
     assert api_helpers.mm_to_m(6500) == 6.5


### PR DESCRIPTION
## Summary
- Add shared geometry ID maps to `anystruct.api_helpers` for flat and cylinder API domains.
- Add `geometry_id_for_domain()` as a small lookup helper.
- Extend helper tests to cover flat IDs, cylinder IDs, and unknown-domain rejection.

## Why
`api.py` still contains embedded geometry ID mapping logic. This PR creates the tested helper surface first, so a later PR can wire `CylStru.set_forces()` to the shared helper without mixing extraction and behavior changes.

## Verification
- Reviewed the branch diff against `modern_dev`.
- Full tests were not run in this Codex environment; please run `python -m pytest` locally and let CI finish before merging.