### PR TITLE
PR10: Add cylinder domain input mode helper

### DIFF
--- a/anystruct/api_helpers.py
+++ b/anystruct/api_helpers.py
@@ -67,6 +67,16 @@ def assert_choice(value, choices, label):
     assert value in choices, f"{label} must be one of: {list(choices)}"
 
 
+def cylinder_input_mode(calculation_domain):
+    assert_choice(calculation_domain, CYLINDER_STRUCTURE_DOMAINS, "calculation_domain")
+    return "Stress" if "panel" in calculation_domain else "Force"
+
+
+def cylinder_domain_with_input_mode(calculation_domain):
+    input_mode = cylinder_input_mode(calculation_domain)
+    return f"{calculation_domain} ({input_mode} input)"
+
+
 def geometry_id_for_domain(calculation_domain):
     return GEOMETRY_IDS[calculation_domain]
 

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -25,9 +25,38 @@ def test_geometry_id_for_cylinder_domain_with_input_mode():
     assert api_helpers.geometry_id_for_domain("Orthogonally Stiffened panel (Stress input)") == 8
 
 
+@pytest.mark.parametrize(
+    ("domain", "expected"),
+    [
+        ("Unstiffened shell", "Force"),
+        ("Longitudinal Stiffened shell", "Force"),
+        ("Unstiffened panel", "Stress"),
+        ("Orthogonally Stiffened panel", "Stress"),
+    ],
+)
+def test_cylinder_input_mode(domain, expected):
+    assert api_helpers.cylinder_input_mode(domain) == expected
+
+
+@pytest.mark.parametrize(
+    ("domain", "expected"),
+    [
+        ("Unstiffened shell", "Unstiffened shell (Force input)"),
+        ("Unstiffened panel", "Unstiffened panel (Stress input)"),
+    ],
+)
+def test_cylinder_domain_with_input_mode(domain, expected):
+    assert api_helpers.cylinder_domain_with_input_mode(domain) == expected
+
+
 def test_geometry_id_rejects_unknown_domain():
     with pytest.raises(KeyError):
         api_helpers.geometry_id_for_domain("Unknown geometry")
+
+
+def test_cylinder_input_mode_rejects_unknown_domain():
+    with pytest.raises(AssertionError, match="calculation_domain must be one of"):
+        api_helpers.cylinder_input_mode("Unknown geometry")
 
 
 def test_unit_conversions():


### PR DESCRIPTION
## Summary
- Add `cylinder_input_mode()` to centralize the shell/panel Force-vs-Stress API rule.
- Add `cylinder_domain_with_input_mode()` to produce the normalized cylinder domain string used by geometry lookups.
- Extend API helper tests for shell/panel modes, formatted domains, and unknown-domain rejection.

## Why
This prepares the next `api.py` wiring pass by centralizing another piece of duplicated cylinder API logic in the already-tested helper module. I kept this PR helper-only because this Codex environment lacks `git`/`gh`; replacing the large `api.py` file through the connector would be unnecessarily risky.

## Verification
- Reviewed the branch diff against `modern_dev`.
- Full tests were not run in this Codex environment; please run `python -m pytest` locally and let CI finish before merging.