### PR TITLE
PR11: Wire cylinder API helpers

### DIFF
--- a/anystruct/api.py
+++ b/anystruct/api.py
@@ -382,9 +382,9 @@ class CylStru():
         '''
         super().__init__()
         api_helpers.assert_choice(calculation_domain, self.geotypes, 'calculation_domain')
-        self._load_type = 'Stress' if 'panel' in calculation_domain else 'Force'
+        self._load_type = api_helpers.cylinder_input_mode(calculation_domain)
 
-        self._calculation_domain = calculation_domain + ' (' + self._load_type + ' input)'
+        self._calculation_domain = api_helpers.cylinder_domain_with_input_mode(calculation_domain)
         self._CylinderMain = CylinderAndCurvedPlate()
         self._CylinderMain.geometry = CylinderAndCurvedPlate.geomeries_map_no_input_spec[calculation_domain]
         self._CylinderMain.ShellObj = Shell()
@@ -446,16 +446,7 @@ class CylStru():
 
         :return:
         '''
-        geomeries = {11: 'Flat plate, stiffened', 10: 'Flat plate, unstiffened',
-                     12: 'Flat plate, stiffened with girder',
-                     1: 'Unstiffened shell (Force input)', 2: 'Unstiffened panel (Stress input)',
-                     3: 'Longitudinal Stiffened shell  (Force input)', 4: 'Longitudinal Stiffened panel (Stress input)',
-                     5: 'Ring Stiffened shell (Force input)', 6: 'Ring Stiffened panel (Stress input)',
-                     7: 'Orthogonally Stiffened shell (Force input)', 8: 'Orthogonally Stiffened panel (Stress input)'}
-        geomeries_map = dict()
-        for key, value in geomeries.items():
-            geomeries_map[value] = key
-        geometry = geomeries_map[self._calculation_domain]
+        geometry = api_helpers.geometry_id_for_domain(self._calculation_domain)
         forces = [Nsd, Msd, Tsd, Qsd]
         sasd, smsd, tTsd, tQsd, shsd = hlp.helper_cylinder_stress_to_force_to_stress(
             stresses=None, forces=forces, geometry=geometry, shell_t=self._CylinderMain.ShellObj.thk,
@@ -755,7 +746,6 @@ if __name__ == '__main__':
     #     print(key, val)
     #
     # print(my_flat.get_special_provisions_results())
-
 
 
 

--- a/tests/test_api_helper_wiring.py
+++ b/tests/test_api_helper_wiring.py
@@ -17,3 +17,13 @@ def test_api_uses_shared_stiffener_normalizer():
     source = api_source.read_text(encoding="utf-8")
 
     assert source.count("api_helpers.normalize_bulb_stiffener_type") == 4
+
+
+def test_api_uses_shared_cylinder_domain_helpers():
+    api_source = Path(__file__).resolve().parents[1] / "anystruct" / "api.py"
+    source = api_source.read_text(encoding="utf-8")
+
+    assert "api_helpers.cylinder_input_mode(calculation_domain)" in source
+    assert "api_helpers.cylinder_domain_with_input_mode(calculation_domain)" in source
+    assert "api_helpers.geometry_id_for_domain(self._calculation_domain)" in source
+    assert "geomeries_map" not in source

--- a/tests/test_api_helper_wiring.py
+++ b/tests/test_api_helper_wiring.py
@@ -26,4 +26,4 @@ def test_api_uses_shared_cylinder_domain_helpers():
     assert "api_helpers.cylinder_input_mode(calculation_domain)" in source
     assert "api_helpers.cylinder_domain_with_input_mode(calculation_domain)" in source
     assert "api_helpers.geometry_id_for_domain(self._calculation_domain)" in source
-    assert "geomeries_map" not in source
+    assert "geomeries = {" not in source


### PR DESCRIPTION
## Summary
- Wire `CylStru.__init__()` to use `api_helpers.cylinder_input_mode()` and `api_helpers.cylinder_domain_with_input_mode()`.
- Wire `CylStru.set_forces()` to use `api_helpers.geometry_id_for_domain()` instead of rebuilding a local geometry map.
- Add a wiring guard test for the cylinder helper usage.

## Why
This consumes the helper surface from PR9/PR10 and removes duplicated cylinder domain logic from `api.py` while keeping the change localized to two methods.

## Verification
- Ran `python -m py_compile anystruct\api.py` in the cloned PR branch.
- Reviewed the GitHub branch diff against `modern_dev`.
- Full test suite was not run in this Codex environment; please run `python -m pytest` locally and let CI finish before merging.