### PR TITLE
PR12: Wire API unit conversions to helpers

### DIFF
--- a/anystruct/api.py
+++ b/anystruct/api.py
@@ -105,15 +105,15 @@ class FlatStru():
         :return:
         :rtype:
         '''
-        self._FlatStructure.mat_yield = mat_yield*1e6
-        self._FlatStructure.E = emodule*1e6
+        self._FlatStructure.mat_yield = api_helpers.mpa_to_pa(mat_yield)
+        self._FlatStructure.E = api_helpers.mpa_to_pa(emodule)
         self._FlatStructure.v = poisson
         self._FlatStructure.mat_factor = material_factor
 
         for sub_cls in [self.Plate, self.Stiffeners, self.Girder]:
             if sub_cls is not None:
-                sub_cls.mat_yield = mat_yield * 1e6
-                sub_cls.E = emodule * 1e6
+                sub_cls.mat_yield = api_helpers.mpa_to_pa(mat_yield)
+                sub_cls.E = api_helpers.mpa_to_pa(emodule)
                 sub_cls.v = poisson
                 sub_cls.mat_factor = material_factor
 
@@ -178,7 +178,7 @@ class FlatStru():
 
         self._FlatStructure.Plate.t = thickness
         self._FlatStructure.Plate.spacing = spacing
-        self._FlatStructure.Plate.span = span/1000
+        self._FlatStructure.Plate.span = api_helpers.mm_to_m(span)
         self._FlatStructure.Plate.girder_lg = 10 # placeholder value
 
     
@@ -426,12 +426,12 @@ class CylStru():
         :rtype:
         '''
 
-        self._CylinderMain.sasd = sasd*1e6
-        self._CylinderMain.smsd = smsd*1e6
-        self._CylinderMain.tTsd = abs(tTsd*1e6)
-        self._CylinderMain.tQsd = abs(tQsd*1e6)
-        self._CylinderMain.psd = psd*1e6
-        self._CylinderMain.shsd = shsd*1e6
+        self._CylinderMain.sasd = api_helpers.mpa_to_pa(sasd)
+        self._CylinderMain.smsd = api_helpers.mpa_to_pa(smsd)
+        self._CylinderMain.tTsd = abs(api_helpers.mpa_to_pa(tTsd))
+        self._CylinderMain.tQsd = abs(api_helpers.mpa_to_pa(tQsd))
+        self._CylinderMain.psd = api_helpers.mpa_to_pa(psd)
+        self._CylinderMain.shsd = api_helpers.mpa_to_pa(shsd)
 
     def set_forces(self, Nsd: float = 0, Msd: float = 0, Tsd: float = 0, Qsd: float = 0, psd: float = 0):
         '''
@@ -481,8 +481,8 @@ class CylStru():
         :return:
         :rtype:
         '''
-        self._CylinderMain.mat_yield = mat_yield*1e6
-        self._CylinderMain.E = emodule*1e6
+        self._CylinderMain.mat_yield = api_helpers.mpa_to_pa(mat_yield)
+        self._CylinderMain.E = api_helpers.mpa_to_pa(emodule)
         self._CylinderMain.v = poisson
         self._CylinderMain.mat_factor = material_factor
     def set_imperfection(self, delta_0 = 0.005):
@@ -578,7 +578,7 @@ class CylStru():
         :return:
         :rtype:
         '''
-        self._CylinderMain.panel_spacing = val/1000
+        self._CylinderMain.panel_spacing = api_helpers.mm_to_m(val)
 
     def set_shell_geometry(self, radius: float = 0, thickness: float = 0,distance_between_rings: float = 0,
                            tot_length_of_shell: float = 0):
@@ -597,15 +597,15 @@ class CylStru():
         :rtype:
         '''
 
-        self._CylinderMain.ShellObj.radius = radius/1000
-        self._CylinderMain.ShellObj.thk = thickness/1000
-        self._CylinderMain.ShellObj.dist_between_rings = distance_between_rings/1000
+        self._CylinderMain.ShellObj.radius = api_helpers.mm_to_m(radius)
+        self._CylinderMain.ShellObj.thk = api_helpers.mm_to_m(thickness)
+        self._CylinderMain.ShellObj.dist_between_rings = api_helpers.mm_to_m(distance_between_rings)
         if tot_length_of_shell == 0:
             # Setting a default.
-            self._CylinderMain.ShellObj.length_of_shell = distance_between_rings * 10/1000
-            self._CylinderMain.ShellObj.tot_cyl_length = distance_between_rings * 10/1000
+            self._CylinderMain.ShellObj.length_of_shell = api_helpers.mm_to_m(distance_between_rings * 10)
+            self._CylinderMain.ShellObj.tot_cyl_length = api_helpers.mm_to_m(distance_between_rings * 10)
         else:
-            self._CylinderMain.ShellObj.tot_cyl_length = tot_length_of_shell/1000
+            self._CylinderMain.ShellObj.tot_cyl_length = api_helpers.mm_to_m(tot_length_of_shell)
 
     def set_shell_buckling_parmeters(self, eff_buckling_length_factor: float = 1.0):
         '''
@@ -746,7 +746,6 @@ if __name__ == '__main__':
     #     print(key, val)
     #
     # print(my_flat.get_special_provisions_results())
-
 
 
 

--- a/tests/test_api_helper_wiring.py
+++ b/tests/test_api_helper_wiring.py
@@ -27,3 +27,11 @@ def test_api_uses_shared_cylinder_domain_helpers():
     assert "api_helpers.cylinder_domain_with_input_mode(calculation_domain)" in source
     assert "api_helpers.geometry_id_for_domain(self._calculation_domain)" in source
     assert "geomeries = {" not in source
+
+
+def test_api_uses_shared_unit_conversions():
+    api_source = Path(__file__).resolve().parents[1] / "anystruct" / "api.py"
+    source = api_source.read_text(encoding="utf-8")
+
+    assert source.count("api_helpers.mpa_to_pa") == 12
+    assert source.count("api_helpers.mm_to_m") == 8


### PR DESCRIPTION
## Summary
- Replace direct MPa-to-Pa and mm-to-m conversions in `anystruct/api.py` with `api_helpers.mpa_to_pa()` and `api_helpers.mm_to_m()`.
- Cover flat material/span setters and cylinder material/stress/geometry setters.
- Add a static wiring test for shared unit conversion helper usage.

## Verification
- `python -m py_compile anystruct\api.py`
- `C:\Users\User1\PyCharmMiscProject\.venv\Scripts\python.exe -m pytest tests\test_api_helper_wiring.py -q`
- `rg "\*\s*1e6|/1000|/ 1000" anystruct\api.py` returned no matches