### PR TITLE
PR13: Use API geometry helper in cylinder constructor

### DIFF
--- a/anystruct/api.py
+++ b/anystruct/api.py
@@ -386,7 +386,7 @@ class CylStru():
 
         self._calculation_domain = api_helpers.cylinder_domain_with_input_mode(calculation_domain)
         self._CylinderMain = CylinderAndCurvedPlate()
-        self._CylinderMain.geometry = CylinderAndCurvedPlate.geomeries_map_no_input_spec[calculation_domain]
+        self._CylinderMain.geometry = api_helpers.geometry_id_for_domain(self._calculation_domain)
         self._CylinderMain.ShellObj = Shell()
         if  calculation_domain in ['Unstiffened shell', 'Unstiffened panel']:
             self._CylinderMain.LongStfObj = None
@@ -746,7 +746,6 @@ if __name__ == '__main__':
     #     print(key, val)
     #
     # print(my_flat.get_special_provisions_results())
-
 
 
 

--- a/tests/test_api_helper_wiring.py
+++ b/tests/test_api_helper_wiring.py
@@ -26,6 +26,7 @@ def test_api_uses_shared_cylinder_domain_helpers():
     assert "api_helpers.cylinder_input_mode(calculation_domain)" in source
     assert "api_helpers.cylinder_domain_with_input_mode(calculation_domain)" in source
     assert "api_helpers.geometry_id_for_domain(self._calculation_domain)" in source
+    assert "geomeries_map_no_input_spec" not in source
     assert "geomeries = {" not in source
 
 


### PR DESCRIPTION
## Summary
- Route `CylStru.__init__()` geometry selection through `api_helpers.geometry_id_for_domain()`.
- Stop relying on the legacy `CylinderAndCurvedPlate.geomeries_map_no_input_spec` map inside the public API constructor.
- Extend the API wiring test to guard against reintroducing the legacy map lookup.

## Verification
- `python -m py_compile anystruct\api.py`
- `C:\Users\User1\PyCharmMiscProject\.venv\Scripts\python.exe -m pytest tests\test_api_helper_wiring.py tests\test_api_helpers.py -q`
- `C:\Users\User1\PyCharmMiscProject\.venv\Scripts\python.exe -c "from anystruct.api import CylStru; from anystruct import api_helpers; [CylStru(domain) for domain in api_helpers.CYLINDER_STRUCTURE_DOMAINS]; print('ok')"`