### PR TITLE
PR17: Use geometry helpers in main application

### DIFF
--- a/anystruct/api_helpers.py
+++ b/anystruct/api_helpers.py
@@ -64,6 +64,8 @@ GEOMETRY_IDS = {
     **CYLINDER_GEOMETRY_IDS,
 }
 
+GEOMETRY_DOMAINS = {value: key for key, value in GEOMETRY_IDS.items()}
+
 
 def assert_choice(value, choices, label):
     assert value in choices, f"{label} must be one of: {list(choices)}"
@@ -81,6 +83,10 @@ def cylinder_domain_with_input_mode(calculation_domain):
 
 def geometry_id_for_domain(calculation_domain):
     return GEOMETRY_IDS[calculation_domain]
+
+
+def domain_for_geometry_id(geometry_id):
+    return GEOMETRY_DOMAINS[geometry_id]
 
 
 def mpa_to_pa(value):

--- a/anystruct/main_application.py
+++ b/anystruct/main_application.py
@@ -2167,7 +2167,7 @@ class Application():
                                                    rely=end_y + delta_y*other_count, relwidth=geo_ent_width*1.9)
                 other_count += 1
 
-            if self._shell_geometries_map[self._new_calculation_domain.get()] in [1,5]:
+            if api_helpers.geometry_id_for_domain(self._new_calculation_domain.get()) in [1,5]:
                 self._lab_shell_en_cap_pressure.place(relx=hor_start,
                                                                 rely= end_y + delta_y*other_count)
                 self._ent_shell_end_cap_pressure_included.place(relx=3  * delta_x,
@@ -5306,7 +5306,7 @@ class Application():
                      7:'Orthogonally Stiffened shell (Force input)', 8:'Orthogonally Stiffened panel (Stress input)'
                     '''
                     domain_string = self._new_calculation_domain.get()
-                    domain_int = self._shell_geometries_map[domain_string]
+                    domain_int = api_helpers.geometry_id_for_domain(domain_string)
 
                     dummy_data = {'span': [api_helpers.mm_to_m(self._new_field_len.get()), 'm'],
                                   'plate_thk': [api_helpers.mm_to_m(self._new_plate_thk.get()), 'm'],
@@ -5370,7 +5370,7 @@ class Application():
                                        'mat_yield': [api_helpers.mpa_to_pa(self._new_shell_yield.get()), 'Pa'],
                                        'panel or shell': ['shell', '']}
 
-                    geometry = self._shell_geometries_map[self._new_calculation_domain.get()]
+                    geometry = api_helpers.geometry_id_for_domain(self._new_calculation_domain.get())
 
                     if self._new_shell_stress_or_force.get() == 1:
                         forces = [self._new_shell_Nsd.get(), self._new_shell_Msd.get(),
@@ -5406,7 +5406,7 @@ class Application():
                                  'tQsd': [api_helpers.mpa_to_pa(tQsd), 'Pa'],
                                  'psd': [api_helpers.mpa_to_pa(self._new_shell_psd.get()), 'Pa'],
                                  'shsd': [api_helpers.mpa_to_pa(shsd), 'Pa'],
-                                 'geometry': [self._shell_geometries_map[self._new_calculation_domain.get()], ''],
+                                 'geometry': [api_helpers.geometry_id_for_domain(self._new_calculation_domain.get()), ''],
                                  'material factor':  [self._new_shell_mat_factor.get(), ''],
                                  'delta0': [0.005, ''],
                                  'fab method ring stf':  [self._new_shell_ring_stf_fab_method.get(), ''],
@@ -5992,7 +5992,7 @@ class Application():
                 self._new_shell_psd.set(main_dict_cyl['psd'][0]/1e6)
                 self._new_shell_shsd.set(main_dict_cyl['shsd'][0]/1e6)
 
-                self._new_calculation_domain.set(CylinderAndCurvedPlate.geomeries[main_dict_cyl['geometry'][0]])
+                self._new_calculation_domain.set(api_helpers.domain_for_geometry_id(main_dict_cyl['geometry'][0]))
                 self._new_shell_mat_factor.set(main_dict_cyl['material factor'][0])
                 self._new_shell_ring_stf_fab_method.set(main_dict_cyl['fab method ring stf'][0])
                 self._new_shell_ring_frame_fab_method.set(main_dict_cyl['fab method ring girder'][0])

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -22,6 +22,11 @@ def test_geometry_id_for_cylinder_domain_with_input_mode(domain, expected):
     assert api_helpers.geometry_id_for_domain(domain) == expected
 
 
+@pytest.mark.parametrize(("domain", "geometry_id"), api_helpers.GEOMETRY_IDS.items())
+def test_domain_for_geometry_id_round_trips(domain, geometry_id):
+    assert api_helpers.domain_for_geometry_id(geometry_id) == domain
+
+
 @pytest.mark.parametrize(
     ("domain", "expected"),
     [
@@ -55,6 +60,11 @@ def test_cylinder_domains_with_input_are_canonical_labels():
 def test_geometry_id_rejects_unknown_domain():
     with pytest.raises(KeyError):
         api_helpers.geometry_id_for_domain("Unknown geometry")
+
+
+def test_domain_for_geometry_id_rejects_unknown_id():
+    with pytest.raises(KeyError):
+        api_helpers.domain_for_geometry_id(999)
 
 
 def test_cylinder_input_mode_rejects_unknown_domain():

--- a/tests/test_main_application_helper_wiring.py
+++ b/tests/test_main_application_helper_wiring.py
@@ -14,6 +14,16 @@ def test_main_application_uses_shared_geometry_menu_helpers():
     assert "Longitudinal Stiffened shell  (Force input)" not in source
 
 
+def test_main_application_uses_geometry_helpers_for_active_lookups():
+    main_source = Path(__file__).resolve().parents[1] / "anystruct" / "main_application.py"
+    source = main_source.read_text(encoding="utf-8")
+
+    assert "api_helpers.geometry_id_for_domain(self._new_calculation_domain.get())" in source
+    assert "api_helpers.domain_for_geometry_id(main_dict_cyl['geometry'][0])" in source
+    assert "self._shell_geometries_map[self._new_calculation_domain.get()]" not in source
+    assert "CylinderAndCurvedPlate.geomeries[main_dict_cyl['geometry'][0]]" not in source
+
+
 def test_main_application_uses_helpers_for_structure_property_unit_conversions():
     main_source = Path(__file__).resolve().parents[1] / "anystruct" / "main_application.py"
     source = main_source.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add `api_helpers.domain_for_geometry_id()` as the reverse lookup for canonical geometry IDs.
- Route main-application active geometry ID lookups through `api_helpers.geometry_id_for_domain()`.
- Route saved cylinder geometry ID loading through `api_helpers.domain_for_geometry_id()` instead of `CylinderAndCurvedPlate.geomeries`.
- Add helper and static wiring tests for the new lookup path.

## Verification
- `python -m py_compile anystruct\api_helpers.py anystruct\main_application.py`
- `C:\Users\User1\PyCharmMiscProject\.venv\Scripts\python.exe -m pytest tests\test_api_helpers.py tests\test_main_application_helper_wiring.py -q`
- `C:\Users\User1\PyCharmMiscProject\.venv\Scripts\python.exe -m pytest tests -q`