### PR TITLE
PR19: Resolve GUI smoke ML file paths

### DIFF
--- a/tests/gui_automatic_run.py
+++ b/tests/gui_automatic_run.py
@@ -1,6 +1,30 @@
 from anystruct import main_application
 import multiprocessing, ctypes, os, pickle
+from pathlib import Path
 import tkinter as tk
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EXTERNAL_ML_FILES = Path(r"C:\python_projects\ANYstructure\anystruct\ml_files")
+
+
+def get_ml_file_directories():
+    directories = []
+    env_dir = os.environ.get("ANYSTRUCTURE_ML_FILES")
+    if env_dir:
+        directories.append(Path(env_dir))
+    directories.extend([REPO_ROOT / "anystruct" / "ml_files", DEFAULT_EXTERNAL_ML_FILES])
+    return directories
+
+
+def resolve_ml_pickle(file_base):
+    file_name = Path(file_base.replace("ml_files\\", "").replace("ml_files/", "") + ".pickle")
+    for directory in get_ml_file_directories():
+        candidate = directory / file_name
+        if candidate.is_file():
+            return candidate
+    searched = ", ".join(str(directory) for directory in get_ml_file_directories())
+    raise FileNotFoundError(f"Could not find {file_name.name} in: {searched}")
 
 
 multiprocessing.freeze_support()
@@ -73,17 +97,8 @@ for mat_fac in [1.1, 1.15]:
         file_base = file_base.replace('XXX', mat_fac_str)
         my_dict['_ML_buckling'][mat_fac][name] = None
 
-        if os.path.isfile(file_base + '.pickle'):
-            file = open(file_base + '.pickle', 'rb')
+        with resolve_ml_pickle(file_base).open('rb') as file:
             my_dict['_ML_buckling'][mat_fac][name] = pickle.load(file)
-            file.close()
-        else:
-            # file = open(self._root_dir +'\\' + file_base + '.pickle', 'rb')
-
-            ml_file = os.path.join('C:\\Github\\ANYstructure\\anystruct\\'+file_base + '.pickle')
-            file = open(ml_file, 'rb')
-            my_dict['_ML_buckling'][mat_fac][name] = pickle.load(file)
-            file.close()
 
 
 my_dict['_ML_classes'] = {0: 'N/A',

--- a/tests/test_gui_automatic_run_wiring.py
+++ b/tests/test_gui_automatic_run_wiring.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_gui_automatic_run_resolves_ml_files_without_github_path():
+    gui_source = Path(__file__).resolve().parent / "gui_automatic_run.py"
+    source = gui_source.read_text(encoding="utf-8")
+
+    assert "ANYSTRUCTURE_ML_FILES" in source
+    assert r"C:\python_projects\ANYstructure\anystruct\ml_files" in source
+    assert "REPO_ROOT / \"anystruct\" / \"ml_files\"" in source
+    assert "resolve_ml_pickle(file_base)" in source
+    assert r"C:\Github\ANYstructure" not in source


### PR DESCRIPTION
## Summary
- Replace the hard-coded `C:\Github\ANYstructure` GUI smoke-test ML fallback with a resolver.
- Check ML pickle files in `ANYSTRUCTURE_ML_FILES`, then repo-local `anystruct/ml_files`, then `C:\python_projects\ANYstructure\anystruct\ml_files`.
- Add a regression test that keeps the smoke runner wired to the portable lookup.

## Verification
- `python -m py_compile tests/gui_automatic_run.py`
- `python -m pytest tests/test_gui_automatic_run_wiring.py -q`
- `python -m pytest tests -q` -> `102 passed`

## Note
- I attempted `tests/gui_automatic_run.py`; it launches but does not return within the two-minute timeout, and an unbuffered 30-second rerun produced no console output. This PR keeps that separate GUI-lifetime issue out of scope and fixes the ML file path blocker only.