### PR TITLE
PR23: Fix SPAN optimizer pressure side lookup

### DIFF
--- a/anystruct/optimize_geometry.py
+++ b/anystruct/optimize_geometry.py
@@ -654,7 +654,7 @@ class CreateOptGeoWindow():
 
                 # Taking properites from the closest line.
                 closet_line = self.opt_find_closest_orig_line(to_find)
-                pressure_side = self._line_to_struc[closet_line].overpressure_side
+                pressure_side = self._line_to_struc[closet_line][0].overpressure_side
                 #print('Closest line', closet_line, p1, p2, to_find)
                 gotten_lat_press = self.app.get_highest_pressure(closet_line)
                 lateral_press.append(gotten_lat_press['normal'] / 1e6)

--- a/tests/test_optimize_geometry_wiring.py
+++ b/tests/test_optimize_geometry_wiring.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_span_optimizer_reads_pressure_side_from_line_structure_bundle():
+    optimize_geometry_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize_geometry.py"
+    source = optimize_geometry_source.read_text(encoding="utf-8")
+
+    assert "self._line_to_struc[closet_line][0].overpressure_side" in source
+    assert "self._line_to_struc[closet_line].overpressure_side" not in source


### PR DESCRIPTION
## Summary
- Fix SPAN optimizer pressure-side lookup to read from the line structure bundle's `AllStructure` object.
- Add a regression test guarding against the old direct list access pattern.

## Root Cause
`_line_to_struc[line]` stores a list bundle, with the `AllStructure` at index `0`. The SPAN optimizer was reading `self._line_to_struc[closet_line].overpressure_side`, which crashes because the bundle itself is a list.

## Verification
- `python -m py_compile anystruct/optimize_geometry.py`
- `python -m pytest tests/test_optimize_geometry_wiring.py -q` -> `1 passed`
- `python -m pytest tests -q` -> `105 passed`