### PR TITLE
PR24: Fix SPAN predefined stiffener lookup

### DIFF
--- a/anystruct/optimize.py
+++ b/anystruct/optimize.py
@@ -317,7 +317,7 @@ def any_smart_loop_geometric(min_var,max_var,deltas,initial_structure_obj,latera
                                                                             fat_obj, fat_press, slamming_press):
         #print(predefiened_stiffener_iter)
         if predefiened_stiffener_iter is not None:
-            this_predefiened_objects = hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj)
+            this_predefiened_objects = hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj.Stiffener)
         else:
             this_predefiened_objects = None
 

--- a/tests/test_optimize_geometry_wiring.py
+++ b/tests/test_optimize_geometry_wiring.py
@@ -7,3 +7,11 @@ def test_span_optimizer_reads_pressure_side_from_line_structure_bundle():
 
     assert "self._line_to_struc[closet_line][0].overpressure_side" in source
     assert "self._line_to_struc[closet_line].overpressure_side" not in source
+
+
+def test_span_optimizer_reads_predefined_sections_from_stiffener_component():
+    optimize_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize.py"
+    source = optimize_source.read_text(encoding="utf-8")
+
+    assert "hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj.Stiffener)" in source
+    assert "hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj)" not in source


### PR DESCRIPTION
## Summary
- Fix SPAN geometric optimization when predefined stiffener sections are enabled.
- Pass the stiffener component into `helper_read_section_file()` instead of the full `AllStructure` bundle object.
- Add a regression test guarding against passing `AllStructure` to the section reader.

## Root Cause
`helper_read_section_file()` modifies section-like objects through `get_structure_prop()` / `set_main_properties()`. SPAN geometric optimization was passing the full `AllStructure`, which does not expose `get_structure_prop()`, causing the runtime crash reported from the SPAN button.

## Verification
- `python -m py_compile anystruct/optimize.py`
- `python -m pytest tests/test_optimize_geometry_wiring.py -q` -> `2 passed`
- `python -m pytest tests -q` -> `106 passed`