### PR TITLE
PR25: Add SPAN line structure access helpers

### DIFF
--- a/anystruct/optimize_geometry.py
+++ b/anystruct/optimize_geometry.py
@@ -654,7 +654,7 @@ class CreateOptGeoWindow():
 
                 # Taking properites from the closest line.
                 closet_line = self.opt_find_closest_orig_line(to_find)
-                pressure_side = self._line_to_struc[closet_line][0].overpressure_side
+                pressure_side = self._line_overpressure_side(closet_line)
                 #print('Closest line', closet_line, p1, p2, to_find)
                 gotten_lat_press = self.app.get_highest_pressure(closet_line)
                 lateral_press.append(gotten_lat_press['normal'] / 1e6)
@@ -803,8 +803,7 @@ class CreateOptGeoWindow():
         point = [pt1[0]+vector[0]*0.5, pt1[1]+vector[1]*0.5]
         if self.opt_find_closest_orig_line(point) == None:
             return None
-        objects = [copy.deepcopy(x) if x != None else None for x in
-                   self._line_to_struc[self.opt_find_closest_orig_line(point)]]
+        objects = self._copy_line_structure_bundle(self.opt_find_closest_orig_line(point))
         objects[0].Plate.set_span(dist(pt1,pt2))
         objects[0].Stiffener.set_span(dist(pt1, pt2))
 
@@ -826,7 +825,7 @@ class CreateOptGeoWindow():
                 current[0] += (vector[0]/distance) * delta
                 current[1] += (vector[1]/distance) * delta
                 if dist(coord,current) <= 0.1:
-                    if self._line_to_struc[key][0].Plate.get_structure_type() not in ('GENERAL_INTERNAL_NONWT', 'FRAME'):
+                    if self._line_structure_type(key) not in ('GENERAL_INTERNAL_NONWT', 'FRAME'):
                         return key
                     else:
                         return None
@@ -1168,7 +1167,7 @@ class CreateOptGeoWindow():
                     coord2 = self.get_point_canvas_coord('point' + str(value[1]))
                     vector = [coord2[0] - coord1[0], coord2[1] - coord1[1]]
                     # drawing a bold line if it is selected
-                    if self._line_to_struc[line][0].Plate.get_structure_type() not in ('GENERAL_INTERNAL_NONWT','FRAME'):
+                    if self._line_structure_type(line) not in ('GENERAL_INTERNAL_NONWT','FRAME'):
 
                         if line in self._active_lines:
                             self._canvas_select.create_line(coord1, coord2, width=6, fill=color,stipple='gray50')
@@ -1272,7 +1271,7 @@ class CreateOptGeoWindow():
 
                 for data_idx, data in enumerate(values[1]):
                     for idx, stuc_info in enumerate(data):
-                        if type(stuc_info) == calc_structure.AllStructure:
+                        if isinstance(stuc_info, AllStructure):
 
                             if y_loc > 700:
                                 y_loc = 120
@@ -1389,6 +1388,21 @@ class CreateOptGeoWindow():
             return save_file, xplot, yplot
         else:
             return None, xplot, yplot
+
+    def _line_structure_bundle(self, line):
+        return self._line_to_struc[line]
+
+    def _line_structure(self, line):
+        return self._line_structure_bundle(line)[0]
+
+    def _line_structure_type(self, line):
+        return self._line_structure(line).Plate.get_structure_type()
+
+    def _line_overpressure_side(self, line):
+        return self._line_structure(line).overpressure_side
+
+    def _copy_line_structure_bundle(self, line):
+        return [copy.deepcopy(item) if item is not None else None for item in self._line_structure_bundle(line)]
 
     def algorithm_info(self):
         ''' When button is clicked, info is displayed.'''
@@ -1586,11 +1600,11 @@ class CreateOptGeoWindow():
                         self._active_lines = []
                         self._active_lines.append(key)
                         if key in self._opt_resutls.keys() and self._opt_resutls[key] != None:
-                            self.draw_properties(init_obj=self._line_to_struc[key][0],
+                            self.draw_properties(init_obj=self._line_structure(key),
                                                 opt_obj=self._opt_resutls[key][0],
                                                  line=key)
                         else:
-                            self.draw_properties(init_obj=self._line_to_struc[key][0], line=key)
+                            self.draw_properties(init_obj=self._line_structure(key), line=key)
                         break
                 self.draw_select_canvas()
         self.draw_select_canvas()

--- a/tests/test_optimize_geometry_wiring.py
+++ b/tests/test_optimize_geometry_wiring.py
@@ -5,7 +5,10 @@ def test_span_optimizer_reads_pressure_side_from_line_structure_bundle():
     optimize_geometry_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize_geometry.py"
     source = optimize_geometry_source.read_text(encoding="utf-8")
 
-    assert "self._line_to_struc[closet_line][0].overpressure_side" in source
+    assert "def _line_overpressure_side(self, line):" in source
+    assert "return self._line_structure(line).overpressure_side" in source
+    assert "pressure_side = self._line_overpressure_side(closet_line)" in source
+    assert "self._line_to_struc[closet_line][0].overpressure_side" not in source
     assert "self._line_to_struc[closet_line].overpressure_side" not in source
 
 
@@ -15,3 +18,23 @@ def test_span_optimizer_reads_predefined_sections_from_stiffener_component():
 
     assert "hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj.Stiffener)" in source
     assert "hlp.helper_read_section_file(predefiened_stiffener_iter, struc_obj)" not in source
+
+
+def test_span_optimizer_uses_helpers_for_line_structure_bundle_access():
+    optimize_geometry_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize_geometry.py"
+    source = optimize_geometry_source.read_text(encoding="utf-8")
+
+    assert "def _line_structure_bundle(self, line):" in source
+    assert "def _line_structure(self, line):" in source
+    assert "def _copy_line_structure_bundle(self, line):" in source
+    assert "_line_to_struc[key][0]" not in source
+    assert "_line_to_struc[line][0]" not in source
+    assert "_line_to_struc[closet_line][0]" not in source
+
+
+def test_span_optimizer_uses_imported_allstructure_type_in_result_drawing():
+    optimize_geometry_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize_geometry.py"
+    source = optimize_geometry_source.read_text(encoding="utf-8")
+
+    assert "isinstance(stuc_info, AllStructure)" in source
+    assert "calc_structure.AllStructure" not in source


### PR DESCRIPTION
## Summary
- Add SPAN-local helpers for reading `_line_to_struc` bundles: structure object, structure type, overpressure side, and copied bundle.
- Replace direct `[0]` bundle indexing in `optimize_geometry.py` with named helpers.
- Fix late SPAN result drawing by checking `AllStructure` through the imported class name instead of an undefined `calc_structure` module alias.
- Extend wiring coverage so the SPAN optimizer does not regress to direct list/object access mistakes or undefined type references.

## Why
The recent SPAN crashes came from treating `_line_to_struc[line]` inconsistently as either a bundle or an object. These helpers keep the current data shape but make the intended access explicit inside the SPAN optimizer. The late result-drawing crash had the same flavor: a stale type reference survived until the optimizer had finished processing.

## Verification
- `python -m py_compile anystruct/optimize_geometry.py`
- `python -m pytest tests/test_optimize_geometry_wiring.py -q` -> `4 passed`
- `python -m pytest tests -q` -> `108 passed`