### PR TITLE
Fix SPAN result string rendering

### DIFF
--- a/anystruct/calc_structure.py
+++ b/anystruct/calc_structure.py
@@ -2619,16 +2619,16 @@ class AllStructure():
 
     def get_one_line_string_mixed(self):
         ''' Returning a one line string. '''
-        return 'pl_'+str(round(self.Plate.s, 1))+'x'+str(round(self.Plate.t,1))+' stf_'+\
+        return 'pl_'+str(round(self.Plate.get_s(), 1))+'x'+str(round(self.Plate.get_pl_thk(),1))+' stf_'+\
                self.Stiffener.get_stiffener_type()+\
-               str(round(self.Stiffener.hw,1))+'x'+str(round(self.Stiffener.tw,1))+'+'\
-               +str(round(self.Stiffener.b,1))+'x'+\
-               str(round(self.Stiffener.tf,1))
+               str(round(self.Stiffener.get_web_h(),1))+'x'+str(round(self.Stiffener.get_web_thk(),1))+'+'\
+               +str(round(self.Stiffener.get_fl_w(),1))+'x'+\
+               str(round(self.Stiffener.get_fl_thk(),1))
 
     def get_extended_string_mixed(self):
         ''' Some more information returned. '''
-        return 'span: '+str(round(self.Plate.span,4))+' structure type: '+ self.Stiffener.get_structure_type() + ' stf. type: ' + \
-               self.Stiffener.get_stiffener_type() + ' pressure side: ' + self.Plate.overpressure_side
+        return 'span: '+str(round(self.Plate.get_span(),4))+' structure type: '+ self.Stiffener.get_structure_type() + ' stf. type: ' + \
+               self.Stiffener.get_stiffener_type() + ' pressure side: ' + self.overpressure_side
 
 class Shell():
     '''

--- a/tests/test_calc_structure_structure.py
+++ b/tests/test_calc_structure_structure.py
@@ -67,3 +67,11 @@ def test_input_properties(structure_cls):
     assert props['spacing'] == ex.obj_dict['spacing']
     assert props['plate_thk'] == ex.obj_dict['plate_thk']
     assert props['panel or shell'] == ['panel', '']
+
+
+def test_all_structure_mixed_strings_use_calc_scantling_getters():
+    scantling = calc.CalcScantlings(_with_panel_default(ex.obj_dict))
+    all_structure = calc.AllStructure(Plate=scantling, Stiffener=scantling)
+
+    assert all_structure.get_one_line_string_mixed().startswith('pl_')
+    assert 'structure type:' in all_structure.get_extended_string_mixed()

--- a/tests/test_optimize_geometry_wiring.py
+++ b/tests/test_optimize_geometry_wiring.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import anystruct.optimize_geometry as optimize_geometry
+
 
 def test_span_optimizer_reads_pressure_side_from_line_structure_bundle():
     optimize_geometry_source = Path(__file__).resolve().parents[1] / "anystruct" / "optimize_geometry.py"
@@ -38,3 +40,35 @@ def test_span_optimizer_uses_imported_allstructure_type_in_result_drawing():
 
     assert "isinstance(stuc_info, AllStructure)" in source
     assert "calc_structure.AllStructure" not in source
+
+
+def test_span_result_drawing_accepts_allstructure_instances(monkeypatch):
+    class FakeCanvas:
+        def __init__(self):
+            self.texts = []
+
+        def delete(self, *args, **kwargs):
+            pass
+
+        def create_text(self, *args, **kwargs):
+            self.texts.append(kwargs.get("text", ""))
+
+    class FakeAllStructure:
+        def get_one_line_string_mixed(self):
+            return "fake structure"
+
+    monkeypatch.setattr(optimize_geometry, "AllStructure", FakeAllStructure)
+    window = optimize_geometry.CreateOptGeoWindow.__new__(optimize_geometry.CreateOptGeoWindow)
+    window._canvas_select = FakeCanvas()
+
+    opt_results = {
+        1: [
+            123.4,
+            [[FakeAllStructure(), None, True, True]],
+            {"objects": [100.0], "frames": [23.4], "scales": [1.0]},
+        ]
+    }
+
+    window.draw_select_canvas(opt_results=opt_results)
+
+    assert any("fake structure" in text for text in window._canvas_select.texts)


### PR DESCRIPTION
## Summary
- Make `AllStructure.get_one_line_string_mixed()` use the `CalcScantlings` getter API instead of legacy short attributes like `s`, `hw`, `tw`, `b`, and `tf`.
- Make `get_extended_string_mixed()` use `get_span()` and `AllStructure.overpressure_side` so SPAN result rendering works with the structures produced by `new_structure`.
- Add regression coverage for mixed string rendering and the SPAN result drawing path.

## Verification
- `python -m py_compile anystruct/calc_structure.py anystruct/optimize_geometry.py`
- `python -m pytest tests -q` -> `110 passed`