### PR TITLE
Add line structure bundle helpers

### DIFF
--- a/anystruct/fatigue_window.py
+++ b/anystruct/fatigue_window.py
@@ -3,9 +3,11 @@ import tkinter as tk
 
 try:
     import anystruct.example_data as test
+    import anystruct.line_structure as line_structure
     import anystruct.SN_curve_parameters as sn
 except ModuleNotFoundError:
     import ANYstructure.anystruct.example_data as test
+    import ANYstructure.anystruct.line_structure as line_structure
     import ANYstructure.anystruct.SN_curve_parameters as sn
 
 
@@ -27,21 +29,22 @@ class CreateFatigueWindow():
             self._initial_fatigue_obj = test.get_fatigue_object()
 
         else:
-            if app._line_to_struc[app._active_line][0] is None:
+            active_bundle = app._line_to_struc[app._active_line]
+            if line_structure.structure(active_bundle) is None:
                 return
-            elif app._line_to_struc[app._active_line][0].Stiffener is None:
+            elif not line_structure.has_stiffener(active_bundle):
                 return
             self.app = app
             self.active_line = app._active_line
             points = app._line_dict[self.active_line]
             coords = (app._point_dict['point'+str(points[0])], app._point_dict['point'+str(points[1])])
             self.pressure_coords = self.get_pressure_point_coord_from_two_points(coords[0], coords[1])
-            self._initial_structure_obj = app._line_to_struc[app._active_line][0].Stiffener
-            self.load_objects = app._line_to_struc[app._active_line][3]
+            self._initial_structure_obj = line_structure.stiffener(active_bundle)
+            self.load_objects = line_structure.loads(active_bundle)
 
             self.comp_objects = [app._tank_dict['comp'+str(comp_i)] for comp_i in
                                  app.get_compartments_for_line(app._active_line)]
-            self._initial_fatigue_obj = app._line_to_struc[self.active_line][2]
+            self._initial_fatigue_obj = line_structure.fatigue(active_bundle)
 
 
         self._frame = master

--- a/anystruct/line_structure.py
+++ b/anystruct/line_structure.py
@@ -1,0 +1,58 @@
+"""Named accessors for the existing line-to-structure bundle format."""
+
+import copy
+
+
+STRUCTURE = 0
+LEGACY_CALC_OBJECT = 1
+FATIGUE = 2
+LOADS = 3
+LOAD_COMBINATIONS = 4
+CYLINDER = 5
+
+
+def structure(bundle):
+    return bundle[STRUCTURE]
+
+
+def plate(bundle):
+    line_structure = structure(bundle)
+    return None if line_structure is None else line_structure.Plate
+
+
+def stiffener(bundle):
+    line_structure = structure(bundle)
+    return None if line_structure is None else line_structure.Stiffener
+
+
+def girder(bundle):
+    line_structure = structure(bundle)
+    return None if line_structure is None else line_structure.Girder
+
+
+def fatigue(bundle):
+    return bundle[FATIGUE]
+
+
+def loads(bundle):
+    return bundle[LOADS]
+
+
+def load_combinations(bundle):
+    return None if len(bundle) <= LOAD_COMBINATIONS else bundle[LOAD_COMBINATIONS]
+
+
+def cylinder(bundle):
+    return None if len(bundle) <= CYLINDER else bundle[CYLINDER]
+
+
+def has_cylinder(bundle):
+    return cylinder(bundle) is not None
+
+
+def has_stiffener(bundle):
+    return stiffener(bundle) is not None
+
+
+def copy_bundle(bundle):
+    return [copy.deepcopy(item) if item is not None else None for item in bundle]

--- a/anystruct/optimize_cylinder.py
+++ b/anystruct/optimize_cylinder.py
@@ -12,11 +12,13 @@ try:
     import anystruct.optimize as op
     import anystruct.example_data as test
     import anystruct.helper as hlp
+    import anystruct.line_structure as line_structure
 except ModuleNotFoundError:
     import ANYstructure.anystruct.main_application as main_application
     import ANYstructure.anystruct.optimize as op
     import ANYstructure.anystruct.example_data as test
     import ANYstructure.anystruct.helper as hlp
+    import ANYstructure.anystruct.line_structure as line_structure
 
 class CreateOptimizeCylinderWindow():
     '''
@@ -90,10 +92,11 @@ class CreateOptimizeCylinderWindow():
                                 9: 'UF below or equal 0.87', 10: 'UF between 0.87 and 1.0', 11: 'UF above 1.0'}
         else:
             self.app = app
-            self._initial_structure_obj = app._line_to_struc[app._active_line][0]
-            self._initial_calc_obj = app._line_to_struc[app._active_line][1]
-            self._initial_cylinder_obj = app._line_to_struc[app._active_line][5]
-            self._fatigue_object = app._line_to_struc[app._active_line][2]
+            active_bundle = app._line_to_struc[app._active_line]
+            self._initial_structure_obj = line_structure.structure(active_bundle)
+            self._initial_calc_obj = line_structure.structure(active_bundle)
+            self._initial_cylinder_obj = line_structure.cylinder(active_bundle)
+            self._fatigue_object = line_structure.fatigue(active_bundle)
             try:
                 self._fatigue_pressure = app.get_fatigue_pressures(app._active_line,
                                                                    self._fatigue_object.get_accelerations())

--- a/anystruct/optimize_geometry.py
+++ b/anystruct/optimize_geometry.py
@@ -13,6 +13,7 @@ try:
     import anystruct.main_application
     import anystruct.optimize as op
     import anystruct.example_data as test
+    import anystruct.line_structure as line_structure
     from anystruct.calc_structure import *
     import anystruct.calc_structure
     from anystruct.helper import *
@@ -20,6 +21,7 @@ except ModuleNotFoundError:
     import ANYstructure.anystruct.main_application
     import ANYstructure.anystruct.optimize as op
     import ANYstructure.anystruct.example_data as test
+    import ANYstructure.anystruct.line_structure as line_structure
     from ANYstructure.anystruct.calc_structure import *
     import ANYstructure.anystruct.calc_structure
     from ANYstructure.anystruct.helper import *
@@ -1393,16 +1395,16 @@ class CreateOptGeoWindow():
         return self._line_to_struc[line]
 
     def _line_structure(self, line):
-        return self._line_structure_bundle(line)[0]
+        return line_structure.structure(self._line_structure_bundle(line))
 
     def _line_structure_type(self, line):
-        return self._line_structure(line).Plate.get_structure_type()
+        return line_structure.plate(self._line_structure_bundle(line)).get_structure_type()
 
     def _line_overpressure_side(self, line):
         return self._line_structure(line).overpressure_side
 
     def _copy_line_structure_bundle(self, line):
-        return [copy.deepcopy(item) if item is not None else None for item in self._line_structure_bundle(line)]
+        return line_structure.copy_bundle(self._line_structure_bundle(line))
 
     def algorithm_info(self):
         ''' When button is clicked, info is displayed.'''

--- a/anystruct/optimize_window.py
+++ b/anystruct/optimize_window.py
@@ -12,12 +12,14 @@ try:
     import anystruct.example_data as test
     import anystruct.example_data as ex
     import anystruct.helper as hlp
+    import anystruct.line_structure as line_structure
     import anystruct.optimize as op
 except ModuleNotFoundError:
     from ANYstructure.anystruct.calc_structure import CalcScantlings, AllStructure
     import ANYstructure.anystruct.example_data as test
     import ANYstructure.anystruct.example_data as ex
     import ANYstructure.anystruct.helper as hlp
+    import ANYstructure.anystruct.line_structure as line_structure
     import ANYstructure.anystruct.optimize as op
 class CreateOptimizeWindow():
     '''
@@ -94,8 +96,9 @@ class CreateOptimizeWindow():
         else:
             self.app = app
 
-            self._initial_calc_obj = app._line_to_struc[app._active_line][0]
-            self._fatigue_object = app._line_to_struc[app._active_line][2]
+            active_bundle = app._line_to_struc[app._active_line]
+            self._initial_calc_obj = line_structure.structure(active_bundle)
+            self._fatigue_object = line_structure.fatigue(active_bundle)
             try:
                 self._fatigue_pressure = app.get_fatigue_pressures(app._active_line,
                                                                    self._fatigue_object.get_accelerations())

--- a/anystruct/report_generator.py
+++ b/anystruct/report_generator.py
@@ -23,9 +23,11 @@ import tkinter as tk
 try:
     import anystruct.example_data as test
     import anystruct.helper as hlp
+    import anystruct.line_structure as line_structure
 except ModuleNotFoundError:
     import ANYstructure.anystruct.example_data as test
     import ANYstructure.anystruct.helper as hlp
+    import ANYstructure.anystruct.line_structure as line_structure
 
 
 
@@ -177,9 +179,10 @@ class LetterMaker(object):
             vpos -= delta
 
             if line in self.data._line_to_struc.keys():
-                if self.data._line_to_struc[line][5] is None:
-                    struc_obj = self.data._line_to_struc[line][0]
-                    fo = self.data._line_to_struc[line][2]
+                line_bundle = self.data._line_to_struc[line]
+                if not line_structure.has_cylinder(line_bundle):
+                    struc_obj = line_structure.structure(line_bundle)
+                    fo = line_structure.fatigue(line_bundle)
                     pressure = self.data.get_highest_pressure(line)['normal']/1000
                     textobject = self.c.beginText()
                     textobject.setTextOrigin(30,vpos)
@@ -277,7 +280,7 @@ class LetterMaker(object):
                                             str(round(max(buc_util),2))+' -> '+'NOT OK')
                     elif self.data._new_buckling_method.get() == 'DNV PULS':
                         if self.data._PULS_results is not None:
-                            puls_method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                            puls_method = line_structure.plate(line_bundle).get_puls_method()
                             textobject.textLine('PULS results using '+str(puls_method) + 'utilization with acceptance '+
                                                 str(self.data._PULS_results.puls_acceptance))
                             if line in self.data._PULS_results.get_run_results().keys():
@@ -295,7 +298,7 @@ class LetterMaker(object):
                                 textobject.setFillColor('black')
 
                     else:
-                        puls_method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                        puls_method = line_structure.plate(line_bundle).get_puls_method()
                         textobject.textLine('ML-CL results using '+str(puls_method) + 'utilization with acceptance 0.87')
                         if line in self.data._PULS_results.get_run_results().keys():
                             ml_buckling = self.data.get_color_and_calc_state()['ML buckling class'][line]['buckling']
@@ -337,7 +340,7 @@ class LetterMaker(object):
                     self.c.drawText(textobject)
                     vpos -= 10
                 else:
-                    cyl_obj = self.data._line_to_struc[line][5]
+                    cyl_obj = line_structure.cylinder(line_bundle)
                     textobject = self.c.beginText()
                     textobject.setTextOrigin(30, vpos)
                     textobject.setFont("Helvetica-Oblique", 10)
@@ -465,6 +468,9 @@ class LetterMaker(object):
         for line, pt in lines.items():
             if line not in list(self.data._line_to_struc.keys()):
                 continue
+            line_bundle = self.data._line_to_struc[line]
+            line_plate = line_structure.plate(line_bundle)
+            line_stiffener = line_structure.stiffener(line_bundle)
             if draw_type == 'UF':
                 if self.data._new_buckling_method.get() == 'DNV-RP-C201 - prescriptive':
                     try:
@@ -473,7 +479,7 @@ class LetterMaker(object):
                         self.c.setStrokeColor('black')
                 elif self.data._new_buckling_method.get() == 'DNV PULS':
                     try:
-                        method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                        method = line_plate.get_puls_method()
                         if self.data._PULS_results is not None:
                             util = self.data._PULS_results.get_utilization(line, method, self.data._new_puls_uf.get())
                             if util is not None:
@@ -482,12 +488,12 @@ class LetterMaker(object):
                         self.c.setStrokeColor('black')
                 else:
 
-                    method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                    method = line_plate.get_puls_method()
                     self.c.setStrokeColor(colors[line][method])
 
-            elif draw_type == 'section' and self.data._line_to_struc[line][0].Stiffener is not None:
+            elif draw_type == 'section' and line_stiffener is not None:
                 self.c.setStrokeColor(all_line_data['color code']['lines'][line]['section'])
-                if self.data._line_to_struc[line][0].Stiffener.get_beam_string() not in drawed_data:
+                if line_stiffener.get_beam_string() not in drawed_data:
                     textobject = self.c.beginText()
                     if 400 - 20 * idx > 20:
                         textobject.setTextOrigin(50, 400 - 20 * idx)
@@ -495,9 +501,9 @@ class LetterMaker(object):
                         textobject.setTextOrigin(300, 400 - 20 * idx)
                     textobject.setFillColor(all_line_data['color code']['lines'][line]['section'])
                     textobject.setFont("Helvetica-Oblique", 10)
-                    textobject.textLine(self.data._line_to_struc[line][0].Stiffener.get_beam_string())
+                    textobject.textLine(line_stiffener.get_beam_string())
                     self.c.drawText(textobject)
-                    drawed_data.append(self.data._line_to_struc[line][0].Stiffener.get_beam_string())
+                    drawed_data.append(line_stiffener.get_beam_string())
                     idx += 1
             elif draw_type == 'plate':
                 self.c.setStrokeColor(all_line_data['color code']['lines'][line]['plate'])
@@ -509,7 +515,7 @@ class LetterMaker(object):
                 elif self.data._new_buckling_method.get() == 'DNV PULS':
                     self.c.setStrokeColor(all_line_data['color code']['lines'][line]['PULS uf color'])
                 else:
-                    puls_method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                    puls_method = line_plate.get_puls_method()
                     self.c.setStrokeColor(matplotlib_colors.rgb2hex(all_line_data['ML buckling colors'][line][puls_method]))
 
             elif draw_type == 'sigma x':
@@ -781,7 +787,8 @@ class LetterMaker(object):
         cylindersy, flat_plates, idx = False, False,-1
         for line in sorted(self.data._line_dict.keys()):
             idx += 1
-            if self.data._line_to_struc[line][5] is None and cylinders is False:
+            line_bundle = self.data._line_to_struc[line]
+            if not line_structure.has_cylinder(line_bundle) and cylinders is False:
                 flat_plates = True
                 if idx == 0:
                     headers = ['Line', 'pl thk', 's', 'web h', 'web thk', 'fl. w', 'fl. thk', 'sig x1', 'sig x2', 'sig y1',
@@ -790,11 +797,11 @@ class LetterMaker(object):
                     table_all.append(headers)
                 if line not in list(self.data._line_to_struc.keys()):
                     continue
-                struc_obj = self.data._line_to_struc[line][0]
+                struc_obj = line_structure.structure(line_bundle)
                 pressure = round(self.data.get_highest_pressure(line)['normal'] / 1000,0)
 
                 if self.data._PULS_results is not None:
-                    puls_method = self.data._line_to_struc[line][0].Plate.get_puls_method()
+                    puls_method = line_structure.plate(line_bundle).get_puls_method()
                     if line in self.data._PULS_results.get_run_results().keys():
                         if puls_method == 'buckling':
                             buckling_uf = \
@@ -841,7 +848,7 @@ class LetterMaker(object):
                                'Hoop stress',
                                'UF shell', 'UF long. stf.', 'UF ring. stf.', 'UF girder']
                     table_all.append(headers)
-                cyl_obj = self.data._line_to_struc[line][5]
+                cyl_obj = line_structure.cylinder(line_bundle)
                 radius = round(cyl_obj.ShellObj.radius * 1000, 2)
                 thickness = round(cyl_obj.ShellObj.thk * 1000, 2)
                 long_str = cyl_obj.LongStfObj.get_beam_string()

--- a/tests/test_line_structure.py
+++ b/tests/test_line_structure.py
@@ -1,0 +1,27 @@
+import anystruct.example_data as ex
+import anystruct.line_structure as line_structure
+
+
+def test_line_structure_accessors_read_existing_bundle_slots():
+    line_bundle = ex.get_line_to_struc()["line1"]
+
+    assert line_structure.structure(line_bundle) is line_bundle[0]
+    assert line_structure.plate(line_bundle) is line_bundle[0].Plate
+    assert line_structure.stiffener(line_bundle) is line_bundle[0].Stiffener
+    assert line_structure.girder(line_bundle) is line_bundle[0].Girder
+    assert line_structure.fatigue(line_bundle) is line_bundle[2]
+    assert line_structure.loads(line_bundle) is line_bundle[3]
+    assert line_structure.load_combinations(line_bundle) is line_bundle[4]
+    assert line_structure.cylinder(line_bundle) is None
+    assert line_structure.has_stiffener(line_bundle)
+    assert not line_structure.has_cylinder(line_bundle)
+
+
+def test_line_structure_copy_bundle_preserves_shape_and_copies_objects():
+    line_bundle = ex.get_line_to_struc()["line1"]
+
+    copied_bundle = line_structure.copy_bundle(line_bundle)
+
+    assert len(copied_bundle) == len(line_bundle)
+    assert copied_bundle is not line_bundle
+    assert line_structure.structure(copied_bundle) is not line_structure.structure(line_bundle)

--- a/tests/test_line_structure_wiring.py
+++ b/tests/test_line_structure_wiring.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_source(path):
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_pr27_target_files_import_line_structure_helpers():
+    for path in [
+        "anystruct/optimize_geometry.py",
+        "anystruct/optimize_window.py",
+        "anystruct/optimize_cylinder.py",
+        "anystruct/fatigue_window.py",
+        "anystruct/report_generator.py",
+    ]:
+        assert "line_structure" in read_source(path)
+
+
+def test_pr27_constructor_paths_use_line_structure_helpers():
+    optimize_window = read_source("anystruct/optimize_window.py")
+    optimize_window_app_branch = optimize_window[
+        optimize_window.index("        else:\n            self.app = app"):
+        optimize_window.index("            try:\n                self._fatigue_pressure")
+    ]
+    assert "line_structure.structure(active_bundle)" in optimize_window_app_branch
+    assert "line_structure.fatigue(active_bundle)" in optimize_window_app_branch
+    assert not re.search(r"_line_to_struc\[[^\n]+]\[[025]]", optimize_window_app_branch)
+
+    optimize_cylinder = read_source("anystruct/optimize_cylinder.py")
+    optimize_cylinder_app_branch = optimize_cylinder[
+        optimize_cylinder.index("        else:\n            self.app = app"):
+        optimize_cylinder.index("            try:\n                self._fatigue_pressure")
+    ]
+    assert "line_structure.structure(active_bundle)" in optimize_cylinder_app_branch
+    assert "line_structure.cylinder(active_bundle)" in optimize_cylinder_app_branch
+    assert "line_structure.fatigue(active_bundle)" in optimize_cylinder_app_branch
+    assert not re.search(r"_line_to_struc\[[^\n]+]\[[0125]]", optimize_cylinder_app_branch)
+
+
+def test_pr27_report_generator_uses_line_structure_for_read_only_access():
+    report_source = read_source("anystruct/report_generator.py")
+
+    assert "line_structure.has_cylinder(line_bundle)" in report_source
+    assert "line_structure.structure(line_bundle)" in report_source
+    assert "line_structure.cylinder(line_bundle)" in report_source
+    assert not re.search(r"_line_to_struc\[[^\n]+]\[[025]]", report_source)


### PR DESCRIPTION
## Summary
- Add `anystruct.line_structure` named accessors for the existing `_line_to_struc` bundle slots while preserving the list-based storage format.
- Convert high-risk read paths in SPAN, single optimizer, cylinder optimizer, fatigue window, and report generation to use the shared helpers.
- Add helper and wiring coverage to pin the compatibility contract and prevent reintroducing selected raw bundle indexes in converted paths.

## Verification
- `python -m py_compile anystruct/line_structure.py anystruct/optimize_geometry.py anystruct/optimize_window.py anystruct/optimize_cylinder.py anystruct/fatigue_window.py anystruct/report_generator.py anystruct/main_application.py anystruct/optimize_multiple_window.py`
- `python -m pytest tests/test_line_structure.py tests/test_line_structure_wiring.py tests/test_optimize_geometry_wiring.py -q` -> `10 passed`
- `python -m pytest tests -q` -> `115 passed`