### PR TITLE
Exercise optimizer windows in GUI smoke

### DIFF
--- a/tests/gui_automatic_run.py
+++ b/tests/gui_automatic_run.py
@@ -1,4 +1,4 @@
-from anystruct import main_application
+from anystruct import calc_structure, example_data, main_application
 import multiprocessing, ctypes, os, pickle
 from pathlib import Path
 import tkinter as tk
@@ -43,6 +43,51 @@ def configure_noninteractive_plots():
 
 def checkpoint(name):
     print(f"gui_automatic_run: {name}", flush=True)
+
+
+def close_child_windows():
+    root.update_idletasks()
+    for child in list(root.winfo_children()):
+        if isinstance(child, tk.Toplevel):
+            child.destroy()
+    root.update_idletasks()
+    plt.close("all")
+
+
+def assert_window_opens(action, name):
+    before = len([child for child in root.winfo_children() if isinstance(child, tk.Toplevel)])
+    action()
+    root.update_idletasks()
+    after = len([child for child in root.winfo_children() if isinstance(child, tk.Toplevel)])
+    if after <= before:
+        raise RuntimeError(f"{name} did not open a Toplevel window")
+    checkpoint(f"{name} opened")
+    close_child_windows()
+
+
+def make_smoke_cylinder():
+    return calc_structure.CylinderAndCurvedPlate(
+        main_dict=example_data.shell_main_dict,
+        shell=calc_structure.Shell(example_data.shell_dict),
+        long_stf=calc_structure.Structure(example_data.obj_dict_cyl_long2),
+        ring_stf=None,
+        ring_frame=None)
+
+
+def exercise_optimizer_windows():
+    my_dict["_active_line"] = "line1"
+    my_dict["_line_is_active"] = True
+    assert_window_opens(my_app.on_optimize, "single optimizer")
+
+    my_dict["_active_line"] = "line2"
+    my_dict["_line_is_active"] = True
+    my_dict["_line_to_struc"]["line2"][5] = make_smoke_cylinder()
+    assert_window_opens(my_app.on_optimize_cylinder, "cylinder optimizer")
+    my_dict["_line_to_struc"]["line2"][5] = None
+
+    my_dict["_multiselect_lines"] = ["line1", "line2"]
+    assert_window_opens(my_app.on_optimize_multiple, "multiple optimizer")
+    assert_window_opens(my_app.on_geometry_optimize, "span optimizer")
 
 
 multiprocessing.freeze_support()
@@ -182,6 +227,8 @@ run_cc_chks()
 print(my_dict['_tank_dict'])
 my_app.on_show_loads()
 checkpoint("loads shown")
+exercise_optimizer_windows()
+checkpoint("optimizer windows exercised")
 root.update_idletasks()
 root.destroy()
 checkpoint("root destroyed")

--- a/tests/test_gui_automatic_run_wiring.py
+++ b/tests/test_gui_automatic_run_wiring.py
@@ -29,3 +29,18 @@ def test_gui_automatic_run_suppresses_plot_windows():
     assert "configure_noninteractive_plots()" in source
     assert "plt.show = lambda *args, **kwargs: None" in source
     assert "plt.close(\"all\")" in source
+
+
+def test_gui_automatic_run_exercises_optimizer_windows_noninteractively():
+    gui_source = Path(__file__).resolve().parent / "gui_automatic_run.py"
+    source = gui_source.read_text(encoding="utf-8")
+
+    assert "def assert_window_opens(action, name):" in source
+    assert "def close_child_windows():" in source
+    assert "def exercise_optimizer_windows():" in source
+    assert "my_app.on_optimize" in source
+    assert "my_app.on_optimize_cylinder" in source
+    assert "my_app.on_optimize_multiple" in source
+    assert "my_app.on_geometry_optimize" in source
+    assert "make_smoke_cylinder()" in source
+    assert "exercise_optimizer_windows()" in source


### PR DESCRIPTION
## Summary
- Extend `tests/gui_automatic_run.py` to open and auto-close the single, cylinder, multiple, and SPAN optimizer windows.
- Add a small smoke cylinder object so cylinder optimizer initialization is covered without Excel/COM or manual setup.
- Keep dialogs and plots noninteractive, and assert each optimizer action creates a `Toplevel` window.

## Verification
- `python -m py_compile tests/gui_automatic_run.py anystruct/main_application.py anystruct/optimize_window.py anystruct/optimize_geometry.py anystruct/optimize_multiple_window.py anystruct/optimize_cylinder.py`
- `python -m pytest tests/test_gui_automatic_run_wiring.py -q` -> `4 passed`
- `python tests/gui_automatic_run.py` -> optimizer windows opened and root destroyed
- `python -m pytest tests -q` -> `118 passed`