### PR TITLE
Fix FEM run popup window maximization and import issues

### DIFF
--- a/anystruct/fe_runtime_solver.py
+++ b/anystruct/fe_runtime_solver.py
@@ -669,10 +669,22 @@ class RuntimeFEMWindow:
         self.window.geometry("1100x760")
         self.window.minsize(980, 640)
         self.window.resizable(True, True)
-        if not use_parent_as_window:
-            self.window.transient(parent)
         try:
             self.window.attributes("-toolwindow", False)
+        except Exception:
+            pass
+        # Position window relative to parent if possible
+        try:
+            if not use_parent_as_window:
+                parent.update_idletasks()
+                root_x = parent.winfo_rootx()
+                root_y = parent.winfo_rooty()
+                root_w = parent.winfo_width()
+                root_h = parent.winfo_height()
+                win_w, win_h = 1100, 760
+                pos_x = root_x + max((root_w - win_w) // 2, 0)
+                pos_y = root_y + max((root_h - win_h) // 2, 0)
+                self.window.geometry(f'{win_w}x{win_h}+{pos_x}+{pos_y}')
         except Exception:
             pass
 

--- a/anystruct/fe_solver_backend/__init__.py
+++ b/anystruct/fe_solver_backend/__init__.py
@@ -1,0 +1,14 @@
+# FEM solver backend package
+from anystruct.fe_solver_backend.anystructure_fem_mode import (
+    AnyStructureFEMConfig,
+    build_fe_model_from_generated_geometry,
+    build_symmetric_load_case,
+    recover_prestress_from_static_result,
+)
+
+__all__ = [
+    'AnyStructureFEMConfig',
+    'build_fe_model_from_generated_geometry',
+    'build_symmetric_load_case',
+    'recover_prestress_from_static_result',
+]


### PR DESCRIPTION
## Summary
- Fix FEM run popup window maximization issue when started from multi mode
- Add missing `__init__.py` for `fe_solver_backend` package to fix import errors

## Problem
1. When starting the "FEM run" from multi mode, the popup window could not be maximized
2. Runtime FEM was failing with: `module 'anystruct.fe_solver_backend' has no attribute 'AnyStructureFEMConfig'`

## Root Causes
1. **Maximization issue**: The `transient(parent)` attribute on the RuntimeFEMWindow was preventing the window from being maximized in certain contexts (specifically when started from multi mode)
2. **Import error**: The `fe_solver_backend` directory was missing an `__init__.py` file, preventing it from being imported as a Python package

## Solutions
1. **Window maximization**: Removed the `transient(parent)` call from RuntimeFEMWindow initialization and added window positioning logic to center the window relative to the parent
2. **Import fix**: Added `__init__.py` file to `fe_solver_backend` package that exports the necessary classes and functions

## Changes Made
- `anystruct/fe_runtime_solver.py`: Removed `transient` call, added window positioning
- `anystruct/fe_solver_backend/__init__.py`: New file to make the package importable

## Verification
- Syntax validation passed for both files
- No existing tests affected
- Window positioning logic follows the same pattern as other dialogs in main_application.py
