### PR TITLE
feat: activate qualified Q4 and S3 runtime policy

### DIFF
--- a/anystruct/fem_integration.py
+++ b/anystruct/fem_integration.py
@@ -414,8 +414,8 @@ def _tk_var_int(variable: Any, default: int = 0) -> int:
 RUNTIME_FEM_STATE_FORMAT_V1 = "anystructure-runtime-fem-state-v1"
 RUNTIME_FEM_STATE_FORMAT = "anystructure-runtime-fem-state-v2"
 RUNTIME_SHELL_AUTHORITY_SCHEMA = "anystructure-runtime-shell-authority-v2"
-RUNTIME_Q4_FORMULATION = "legacy"
-RUNTIME_S3_FORMULATION = "legacy-s3"
+RUNTIME_Q4_FORMULATION = "e4-pl"
+RUNTIME_S3_FORMULATION = "e4-pl-s3-v2d"
 
 
 def _runtime_formulation_for_node_count(node_count: int) -> str:
@@ -454,11 +454,11 @@ def _runtime_shell_authority(
     return {
         "schema": RUNTIME_SHELL_AUTHORITY_SCHEMA,
         "q4_formulation": RUNTIME_Q4_FORMULATION,
-        "q4_formulation_id": "LEGACY_SHELL_ELEMENT_Q4",
+        "q4_formulation_id": "E4_PL_QUALIFIED_Q4_HYBRID_V2",
         "s3_formulation": RUNTIME_S3_FORMULATION,
-        "s3_formulation_id": "LEGACY_SHELL_ELEMENT_TRI3",
-        "physical_normal_authority": "NOT_REQUIRED_LEGACY_SHELL_POLICY",
-        "migration_disposition": "CURRENT_EXPLICIT_LEGACY_POLICY",
+        "s3_formulation_id": "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1",
+        "physical_normal_authority": "PHYSICAL_SURFACE_OWNER_NORMAL_V2D_V1",
+        "migration_disposition": "CURRENT_QUALIFIED_Q4_S3_V2D_POLICY",
     }
 
 
@@ -501,7 +501,7 @@ def runtime_shell_authority_allows_hot_restart(value: Any) -> bool:
 
 
 def _imported_model_shell_authority(model: Any) -> dict[str, Any]:
-    """Accept only exact legacy shell classes under the current hold policy."""
+    """Accept current authority only for exact qualified shell classes."""
 
     if model is None:
         return _runtime_shell_authority()
@@ -511,7 +511,16 @@ def _imported_model_shell_authority(model: Any) -> dict[str, Any]:
         return _runtime_shell_authority(imported_legacy=True)
 
     shell_type = getattr(_anysolver_package, "ShellElement", None)
-    if not isinstance(shell_type, type):
+    qualified_q4_type = getattr(
+        _anysolver_package, "QualifiedE4PLShellElement", None
+    )
+    qualified_s3_type = getattr(
+        _anysolver_package, "NativeParityE4PLS3V2DShellElement", None
+    )
+    if not all(
+        isinstance(item, type)
+        for item in (shell_type, qualified_q4_type, qualified_s3_type)
+    ):
         return _runtime_shell_authority(imported_legacy=True)
 
     try:
@@ -525,7 +534,35 @@ def _imported_model_shell_authority(model: Any) -> dict[str, Any]:
             node_count = len(element.node_ids)
         except Exception:
             return _runtime_shell_authority(imported_legacy=True)
-        if node_count in {3, 4, 6, 8} and type(element) is not shell_type:
+        if node_count == 3:
+            if (
+                type(element) is not qualified_s3_type
+                or getattr(type(element), "formulation_id", None)
+                != "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1"
+            ):
+                return _runtime_shell_authority(imported_legacy=True)
+            try:
+                reference_normal = np.asarray(
+                    object.__getattribute__(element, "reference_normal"),
+                    dtype=float,
+                )
+            except Exception:
+                return _runtime_shell_authority(imported_legacy=True)
+            if (
+                reference_normal.shape != (3,)
+                or not np.all(np.isfinite(reference_normal))
+                or not math.isclose(
+                    float(np.linalg.norm(reference_normal)),
+                    1.0,
+                    rel_tol=0.0,
+                    abs_tol=1.0e-12,
+                )
+            ):
+                return _runtime_shell_authority(imported_legacy=True)
+        elif node_count == 4:
+            if type(element) is not qualified_q4_type:
+                return _runtime_shell_authority(imported_legacy=True)
+        elif node_count in {6, 8} and type(element) is not shell_type:
             return _runtime_shell_authority(imported_legacy=True)
     return _runtime_shell_authority()
 
@@ -741,7 +778,7 @@ def load_runtime_fem_state(path: Any) -> dict[str, Any]:
     elif historical_qualified:
         migration_diagnostics.append(
             "RUNTIME_FEM_V2_QUALIFIED_V1_POLICY_RETAINED_READ_ONLY: S3 V1 was "
-            "rejected and downstream qualified Q4 is on hold; hot restart is forbidden"
+            "superseded by qualified V2D; hot restart is forbidden"
         )
     elif migrated_v1 or legacy_migration:
         migration_diagnostics.append(
@@ -1608,7 +1645,7 @@ def build_runtime_generated_geometry(
     geometry: dict[str, Any] | geometry_generators.GeometryBackedProjection,
     config: Any,
 ) -> geometry_generators.GeometryBackedProjection:
-    """Build the legacy FE/render payload from a geometry-backed projection."""
+    """Build a formulation-authorized FE/render payload."""
 
     projection = (
         geometry_generators.project_runtime_geometry(geometry.geometry_authority)
@@ -1632,7 +1669,26 @@ def build_runtime_generated_geometry(
                 raise ValueError(
                     f"runtime {collection_name} formulation record has invalid nodes"
                 ) from error
-            record["formulation"] = _runtime_formulation_for_node_count(node_count)
+            formulation = _runtime_formulation_for_node_count(node_count)
+            record["formulation"] = formulation
+            if node_count == 4:
+                record["formulation_id"] = "E4_PL_QUALIFIED_Q4_HYBRID_V2"
+            elif node_count == 3:
+                normal = record.get(
+                    "reference_normal",
+                    record.get("owner_normal", record.get("physical_normal")),
+                )
+                if normal is None:
+                    raise ValueError(
+                        "runtime qualified S3 record lacks physical owner-normal authority"
+                    )
+                record["reference_normal"] = normal
+                record["owner_normal_authority"] = (
+                    "PHYSICAL_SURFACE_OWNER_NORMAL_V2D_V1"
+                )
+                record["formulation_id"] = (
+                    "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1"
+                )
     return geometry_generators.project_runtime_payload(
         generated,
         projection.geometry_authority,
@@ -1698,9 +1754,21 @@ def run_runtime_fem(snapshot: RuntimeFEMLineSnapshot, options: RuntimeFEMOptions
     custom_edges = _runtime_custom_edges(options)
     local_refinement_patches = _runtime_local_refinement_patches(options)
     warmup_state = fe_solver_kernel_warmup_status()
-    solve_outcome = solver_result.outcome.to_dict()
+    # The public runtime facade intentionally returns a lightweight result;
+    # normalize it through ANYsolver's common outcome adapter instead of
+    # assuming every result class stores an ``outcome`` attribute directly.
+    try:
+        solve_outcome = _anysolver_package.solve_outcome(solver_result).to_dict()
+    except TypeError:
+        # Retain the narrow adapter seam used by tests and older external
+        # result providers that already expose a canonical outcome object.
+        raw_outcome = getattr(solver_result, "outcome", None)
+        if raw_outcome is None or not callable(getattr(raw_outcome, "to_dict", None)):
+            raise
+        solve_outcome = raw_outcome.to_dict()
     quantity_descriptors = tuple(
-        descriptor.to_dict() for descriptor in solver_result.quantity_metadata
+        descriptor.to_dict()
+        for descriptor in _anysolver_package.describe_result_quantities(solver_result)
     )
     reaction_descriptors = tuple(
         descriptor
@@ -11644,8 +11712,8 @@ class RuntimeFEMWindow:
             getattr(self, "_loaded_shell_authority", _runtime_shell_authority())
         ):
             message = (
-                "This loaded or imported model does not carry the current explicit "
-                "legacy Q4/S3 application policy and cannot be hot-restarted. Replay "
+                "This loaded or imported model does not carry the current qualified "
+                "Q4/S3 V2D application policy and cannot be hot-restarted. Replay "
                 "the full load history in a new current-policy model before running FEM."
             )
             self._write_status(message, keep_run_results=True)

--- a/tests/test_fe_runtime_solver.py
+++ b/tests/test_fe_runtime_solver.py
@@ -511,12 +511,12 @@ def test_runtime_fem_state_save_load_round_trip(tmp_path):
         assert state["migration_diagnostics"] == []
         assert state["shell_authority"] == {
             "schema": "anystructure-runtime-shell-authority-v2",
-            "q4_formulation": "legacy",
-            "q4_formulation_id": "LEGACY_SHELL_ELEMENT_Q4",
-            "s3_formulation": "legacy-s3",
-            "s3_formulation_id": "LEGACY_SHELL_ELEMENT_TRI3",
-            "physical_normal_authority": "NOT_REQUIRED_LEGACY_SHELL_POLICY",
-            "migration_disposition": "CURRENT_EXPLICIT_LEGACY_POLICY",
+            "q4_formulation": "e4-pl",
+            "q4_formulation_id": "E4_PL_QUALIFIED_Q4_HYBRID_V2",
+            "s3_formulation": "e4-pl-s3-v2d",
+            "s3_formulation_id": "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1",
+            "physical_normal_authority": "PHYSICAL_SURFACE_OWNER_NORMAL_V2D_V1",
+            "migration_disposition": "CURRENT_QUALIFIED_Q4_S3_V2D_POLICY",
         }
         assert state["options"] == options
         assert state["snapshot"]["line_name"] == snapshot.line_name

--- a/tests/test_runtime_geometry_authority.py
+++ b/tests/test_runtime_geometry_authority.py
@@ -102,10 +102,20 @@ _CASES = (
 
 
 def _without_shell_formulations(payload: dict[str, Any]) -> dict[str, Any]:
+    authority_fields = {
+        "formulation",
+        "formulation_id",
+        "owner_normal_authority",
+        "reference_normal",
+    }
     return {
         **payload,
         "shells": [
-            {key: value for key, value in shell.items() if key != "formulation"}
+            {
+                key: value
+                for key, value in shell.items()
+                if key not in authority_fields
+            }
             for shell in payload["shells"]
         ],
     }
@@ -162,7 +172,7 @@ def test_runtime_projection_preserves_legacy_fe_payload_and_owner_groups(
     assert len(generated["shells"]) == len(legacy["shells"])
     assert all(
         shell["formulation"] == (
-            "legacy-s3" if len(shell["node_ids"]) == 3 else "legacy"
+            "e4-pl-s3-v2d" if len(shell["node_ids"]) == 3 else "e4-pl"
         )
         for shell in generated["shells"]
     )
@@ -264,6 +274,6 @@ def test_runtime_solver_handoff_receives_geometry_backed_projection(
     assert handed_off.geometry_model.group("transverse_stiffeners")
     assert captured["generated"] is not None
     assert all(
-        shell["formulation"] in {"legacy", "legacy-s3"}
+        shell["formulation"] in {"e4-pl", "e4-pl-s3-v2d"}
         for shell in captured["generated"]["shells"]
     )

--- a/tests/test_s3_runtime_state_v2.py
+++ b/tests/test_s3_runtime_state_v2.py
@@ -11,7 +11,7 @@ from anysolver import LegacyShellElement, create_shell_element
 from anystruct import fem_integration
 
 
-def test_new_runtime_state_binds_explicit_legacy_q4_and_s3() -> None:
+def test_new_runtime_state_binds_qualified_q4_and_v2d_s3() -> None:
     state = fem_integration.runtime_fem_state_to_dict(
         fem_integration.RuntimeFEMOptions()
     )
@@ -19,12 +19,12 @@ def test_new_runtime_state_binds_explicit_legacy_q4_and_s3() -> None:
     assert state["format"] == "anystructure-runtime-fem-state-v2"
     assert state["shell_authority"] == {
         "schema": "anystructure-runtime-shell-authority-v2",
-        "q4_formulation": "legacy",
-        "q4_formulation_id": "LEGACY_SHELL_ELEMENT_Q4",
-        "s3_formulation": "legacy-s3",
-        "s3_formulation_id": "LEGACY_SHELL_ELEMENT_TRI3",
-        "physical_normal_authority": "NOT_REQUIRED_LEGACY_SHELL_POLICY",
-        "migration_disposition": "CURRENT_EXPLICIT_LEGACY_POLICY",
+        "q4_formulation": "e4-pl",
+        "q4_formulation_id": "E4_PL_QUALIFIED_Q4_HYBRID_V2",
+        "s3_formulation": "e4-pl-s3-v2d",
+        "s3_formulation_id": "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1",
+        "physical_normal_authority": "PHYSICAL_SURFACE_OWNER_NORMAL_V2D_V1",
+        "migration_disposition": "CURRENT_QUALIFIED_Q4_S3_V2D_POLICY",
     }
 
 
@@ -159,7 +159,7 @@ def test_superseded_631_qualified_policy_remains_readable_but_not_restartable(
     assert restored["shell_authority"] == state["shell_authority"]
     assert restored["migration_diagnostics"] == [
         "RUNTIME_FEM_V2_QUALIFIED_V1_POLICY_RETAINED_READ_ONLY: S3 V1 was "
-        "rejected and downstream qualified Q4 is on hold; hot restart is forbidden"
+        "superseded by qualified V2D; hot restart is forbidden"
     ]
     assert not fem_integration.runtime_shell_authority_allows_hot_restart(
         restored["shell_authority"]
@@ -170,11 +170,11 @@ def _imported_model_with(element):
     return SimpleNamespace(mesh=SimpleNamespace(elements={1: element}))
 
 
-def test_imported_qualified_s3_is_incompatible_with_legacy_hold_policy() -> None:
+def test_imported_exact_v2d_s3_retains_current_authority() -> None:
     element = create_shell_element(
         1,
         [1, 2, 3],
-        formulation="e4-pl-s3",
+        formulation="e4-pl-s3-v2d",
         reference_normal=(0.0, 0.0, 1.0),
     )
 
@@ -182,13 +182,11 @@ def test_imported_qualified_s3_is_incompatible_with_legacy_hold_policy() -> None
         _imported_model_with(element)
     )
 
-    assert authority == fem_integration._runtime_shell_authority(
-        imported_legacy=True
-    )
-    assert not fem_integration.runtime_shell_authority_allows_hot_restart(authority)
+    assert authority == fem_integration._runtime_shell_authority()
+    assert fem_integration.runtime_shell_authority_allows_hot_restart(authority)
 
 
-def test_imported_exact_legacy_s3_saves_and_reloads_as_current_policy(
+def test_imported_legacy_s3_saves_and_reloads_as_nonrestartable_legacy(
     tmp_path,
 ) -> None:
     legacy = LegacyShellElement(1, [1, 2, 3])
@@ -210,10 +208,13 @@ def test_imported_exact_legacy_s3_saves_and_reloads_as_current_policy(
 
     assert restored["shell_authority"]["s3_formulation"] == "legacy-s3"
     assert restored["shell_authority"]["physical_normal_authority"] == (
-        "NOT_REQUIRED_LEGACY_SHELL_POLICY"
+        "UNPROVEN_IMPORTED_MODEL"
     )
-    assert restored["migration_diagnostics"] == []
-    assert fem_integration.runtime_shell_authority_allows_hot_restart(
+    assert restored["migration_diagnostics"] == [
+        "IMPORTED_MODEL_SHELLS_RETAINED_AS_UNPROVEN_LEGACY: exact "
+        "application policy authority was not proven; hot restart is forbidden"
+    ]
+    assert not fem_integration.runtime_shell_authority_allows_hot_restart(
         restored["shell_authority"]
     )
 

--- a/tests/test_shell_formulation_hold.py
+++ b/tests/test_shell_formulation_hold.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import warnings
-
-from anysolver import LegacyQ4DeprecationWarning, ShellElement
+from anysolver import (
+    NativeParityE4PLS3V2DShellElement,
+    QualifiedE4PLShellElement,
+    ShellElement,
+)
 from anysolver.anystructure_fem_mode import (
     AnyStructureFEMConfig,
     build_fe_model_from_generated_geometry,
@@ -12,14 +14,14 @@ from anysolver import runtime as solver_runtime
 from anystruct import fem_integration
 
 
-def test_runtime_policy_is_legacy_for_every_supported_shell_topology() -> None:
-    assert fem_integration._runtime_formulation_for_node_count(3) == "legacy-s3"
-    assert fem_integration._runtime_formulation_for_node_count(4) == "legacy"
+def test_runtime_policy_selects_qualified_q4_and_v2d_s3() -> None:
+    assert fem_integration._runtime_formulation_for_node_count(3) == "e4-pl-s3-v2d"
+    assert fem_integration._runtime_formulation_for_node_count(4) == "e4-pl"
     assert fem_integration._runtime_formulation_for_node_count(6) == "legacy"
     assert fem_integration._runtime_formulation_for_node_count(8) == "legacy"
 
 
-def test_generated_geometry_carries_explicit_legacy_formulations(monkeypatch) -> None:
+def test_generated_geometry_carries_exact_current_formulation_authority(monkeypatch) -> None:
     projection = fem_integration.geometry_generators.project_runtime_geometry(
         fem_integration.geometry_generators.build_runtime_geometry_authority(
             {
@@ -34,7 +36,11 @@ def test_generated_geometry_carries_explicit_legacy_formulations(monkeypatch) ->
     )
     generated = {
         "shells": [
-            {"id": 1, "node_ids": [1, 2, 3]},
+            {
+                "id": 1,
+                "node_ids": [1, 2, 3],
+                "reference_normal": [0.0, 0.0, 1.0],
+            },
             {"id": 2, "node_ids": [1, 2, 3, 4]},
         ]
     }
@@ -47,12 +53,21 @@ def test_generated_geometry_carries_explicit_legacy_formulations(monkeypatch) ->
     result = fem_integration.build_runtime_generated_geometry(projection, object())
 
     assert [item["formulation"] for item in result["shells"]] == [
-        "legacy-s3",
-        "legacy",
+        "e4-pl-s3-v2d",
+        "e4-pl",
     ]
+    assert result["shells"][0]["formulation_id"] == (
+        "CANDIDATE_E4_PL_S3_V2D_NATIVE_PARITY_V1"
+    )
+    assert result["shells"][0]["owner_normal_authority"] == (
+        "PHYSICAL_SURFACE_OWNER_NORMAL_V2D_V1"
+    )
+    assert result["shells"][1]["formulation_id"] == (
+        "E4_PL_QUALIFIED_Q4_HYBRID_V2"
+    )
 
 
-def test_explicit_runtime_policy_constructs_legacy_q4_elements() -> None:
+def test_runtime_policy_constructs_qualified_q4_elements() -> None:
     summary = {
         "geometry": "flat panel",
         "length_m": 1.0,
@@ -63,12 +78,10 @@ def test_explicit_runtime_policy_constructs_legacy_q4_elements() -> None:
     }
     config = solver_runtime.LightweightFEMConfig(mesh_fidelity="coarse")
     generated = fem_integration.build_runtime_generated_geometry(summary, config)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", LegacyQ4DeprecationWarning)
-        model = build_fe_model_from_generated_geometry(
-            generated,
-            AnyStructureFEMConfig(),
-        )
+    model = build_fe_model_from_generated_geometry(
+        generated,
+        AnyStructureFEMConfig(),
+    )
 
     shells = [
         element
@@ -76,4 +89,50 @@ def test_explicit_runtime_policy_constructs_legacy_q4_elements() -> None:
         if isinstance(element, ShellElement)
     ]
     assert shells
-    assert all(type(element) is ShellElement for element in shells)
+    assert all(type(element) is QualifiedE4PLShellElement for element in shells)
+
+
+def test_generated_v2d_record_constructs_exact_s3_class(monkeypatch) -> None:
+    projection = fem_integration.geometry_generators.project_runtime_geometry(
+        fem_integration.geometry_generators.build_runtime_geometry_authority(
+            {
+                "geometry": "flat panel",
+                "length_m": 1.0,
+                "width_m": 1.0,
+                "plate_thickness_m": 0.01,
+            },
+            include_stiffeners=False,
+            include_girders=False,
+        )
+    )
+    generated = {
+        "nodes": [
+            {"id": 1, "coords": [0.0, 0.0, 0.0]},
+            {"id": 2, "coords": [1.0, 0.0, 0.0]},
+            {"id": 3, "coords": [0.5, 0.8660254037844386, 0.0]},
+        ],
+        "shells": [
+            {
+                "id": 1,
+                "node_ids": [1, 2, 3],
+                "thickness": 0.01,
+                "material": "steel",
+                "reference_normal": [0.0, 0.0, 1.0],
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        fem_integration.fe_solver,
+        "build_generated_geometry",
+        lambda _projection, _config: generated,
+    )
+
+    authorized = fem_integration.build_runtime_generated_geometry(
+        projection, object()
+    )
+    model = build_fe_model_from_generated_geometry(
+        authorized,
+        AnyStructureFEMConfig(),
+    )
+
+    assert type(model.mesh.get_element(1)) is NativeParityE4PLS3V2DShellElement


### PR DESCRIPTION
## Summary
- bind current runtime geometry to qualified Q4 e4-pl and S3 V2D
- require exact formulation and physical-owner-normal authority
- preserve historical runtime states as explicit legacy migrations
- use public ANYsolver outcome and quantity metadata adapters

## Validation
- 22 focused runtime, policy, and migration tests passed
- git diff --check passed
- isolated ecosystem wheel smoke passed
- package version remains 6.3.1